### PR TITLE
Memhunt

### DIFF
--- a/Includes/font.h
+++ b/Includes/font.h
@@ -12,7 +12,6 @@ class Font {
 private:
   bool textureHelper(menuItem* mI, SDL_Color const& c, Renderer* r);
   TTF_Font* font;
-  size_t texH, texW;
   SDL_Color active, passive;
 public:
   Font(const char* path);

--- a/Includes/menuItem.cpp
+++ b/Includes/menuItem.cpp
@@ -10,23 +10,32 @@ menuItem::menuItem(const char* text) :
   menuItem(const_cast<char*>(text)) {
 }
 
+menuItem::menuItem(const menuItem& itm) :
+  menuItem(itm.getLabel()) {
+  this->setTexture(itm.getTexture());
+}
+
 menuItem::~menuItem() {
   if (texture != nullptr) {
     SDL_DestroyTexture(texture);
     texture = nullptr;
   }
+  if (label != nullptr) {
+    free(label);
+    label = nullptr;
+  }
 }
 
-const char* menuItem::getLabel() {
+const char* menuItem::getLabel() const {
   return label;
 }
 
-void menuItem::setLabel(char* text) {
+void menuItem::setLabel(const char* text) {
   label = (char*)realloc(label, strlen(text) * sizeof(char) + 1);
   strcpy(label, text);
 }
 
-SDL_Texture* menuItem::getTexture() {
+SDL_Texture* menuItem::getTexture() const{
   return texture;
 }
 

--- a/Includes/menuItem.h
+++ b/Includes/menuItem.h
@@ -12,12 +12,13 @@ private:
 public:
   menuItem(char* text);
   menuItem(const char* text);
+  menuItem(const menuItem& itm);
   ~menuItem();
 
-  const char* getLabel();
-  void setLabel(char* text);
+  const char* getLabel() const;
+  void setLabel(const char* text);
 
-  SDL_Texture* getTexture();
+  SDL_Texture* getTexture() const;
   void setTexture(SDL_Texture* t);
 };
 #endif

--- a/Includes/vector.hpp
+++ b/Includes/vector.hpp
@@ -1,6 +1,7 @@
 #ifndef VECTOR_HPP
 #define VECTOR_HPP
 
+#include <assert.h>
 #include <stdlib.h>
 
 template<class T>
@@ -16,6 +17,9 @@ public:
   vector() {
     m_size = 4;
     items = static_cast<T**>(malloc(m_size * sizeof(T*)));
+    for (int i = 0; i < m_size; ++i) {
+      items[i] = nullptr;
+    }
     m_length = 0;
   }
 
@@ -24,6 +28,7 @@ public:
       clear();
     }
     free(items);
+    items = nullptr;
   }
 
   void clear() {
@@ -39,6 +44,9 @@ public:
     if (m_length == m_size) {
       m_size = m_size<<1;
       items = static_cast<T**>(realloc(items, m_size * sizeof(T*)));
+      for (int i = m_length; i < m_size; ++i) {
+        items[i] = nullptr;
+      }
     }
     T* t = new T(item);
     items[m_length] = t;
@@ -46,8 +54,11 @@ public:
   }
 
   void pop_back() {
+    if (empty()) {
+      return;
+    }
     items[m_length - 1]->~T;
-    free(items[m_length - 1]);
+    delete(items[m_length - 1]);
     items[m_length - 1] = nullptr;
     --m_length;
   }
@@ -71,6 +82,7 @@ public:
 #else
       // We should probably do something here but `throw`
       // is not yet implemented in NXDK.
+      assert(false);
 #endif
     }
     return *items[key];

--- a/Includes/xbeMenuItem.cpp
+++ b/Includes/xbeMenuItem.cpp
@@ -9,17 +9,23 @@ xbeMenuItem::xbeMenuItem(char* text, char* p) :
 xbeMenuItem::xbeMenuItem(const char* text, const char* p) :
   xbeMenuItem(const_cast<char*>(text), const_cast<char*>(p)) {}
 
+xbeMenuItem::xbeMenuItem(xbeMenuItem const& item) :
+  xbeMenuItem(item.getLabel(), item.getXBEPath()) {
+  this->setTexture(item.getTexture());
+}
+
 xbeMenuItem::~xbeMenuItem() {
-  if (getTexture() != nullptr) {
-    SDL_DestroyTexture(getTexture());
-    setTexture(nullptr);
+  if (xbePath != nullptr) {
+    free(xbePath);
+    xbePath = nullptr;
   }
 }
 
-char* xbeMenuItem::getXBEPath() {
+const char* xbeMenuItem::getXBEPath() const {
   return xbePath;
 }
 
-void xbeMenuItem::setXBEPath(char* p) {
-  xbePath = p;
+void xbeMenuItem::setXBEPath(const char* p) {
+  xbePath = static_cast<char*>(realloc(xbePath, strlen(p) * sizeof(char) + 1));
+  strcpy(xbePath, p);
 }

--- a/Includes/xbeMenuItem.h
+++ b/Includes/xbeMenuItem.h
@@ -9,9 +9,10 @@ private:
 public:
   xbeMenuItem(char* text, char* p);
   xbeMenuItem(const char* text, const char* p);
+  xbeMenuItem(xbeMenuItem const& item);
   ~xbeMenuItem();
-  char* getXBEPath();
-  void setXBEPath(char* p);
+  const char* getXBEPath() const;
+  void setXBEPath(const char* p);
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,7 @@ int main(void) {
   vector<menuItem> mainMenu;
   vector<xbeMenuItem> gamesList;
   if (init == 0) {
+    bool running = true;
     // Create the worker thread for populating the games list
     xbeFinderArg xfa;
     xfa.list = &gamesList;
@@ -71,7 +72,7 @@ int main(void) {
     r.flip();
     int currItem = 0, prevItem = 0, listSize = mainMenu.size();
 
-    while (1) {
+    while (running) {
       // FIXME: Abstract the input- and menu navigation process
 #ifdef NXDK
       XInput_GetEvents();
@@ -177,9 +178,7 @@ int main(void) {
         mainMenuSelection = 0;
         break;
       case 5:
-#ifdef NXDK
-        XReboot();
-#endif
+        running = false;
         prevItem = 0;
         currItem = 4;
         mainMenuSelection = 0;
@@ -189,8 +188,6 @@ int main(void) {
       }
     }
   }
-  mainMenu.clear();
-  gamesList.clear();
   shutdown_systems(init);
   return init;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -145,7 +145,7 @@ int main(void) {
 #ifdef NXDK
         if (getAnalogKeyDown(&g_Pads[0], XPAD_A)) {
           if (currItem != (gamesList.size() - 1)) {
-            XLaunchXBE(gamesList[currItem].getXBEPath());
+            XLaunchXBE(const_cast<char*>(gamesList[currItem].getXBEPath()));
           }
           goToMainMenu(&gamesList[currItem], &r, f, listSize, currItem, prevItem,
                        mainMenuSelection);


### PR DESCRIPTION
This reduces leaked memory quite a bit - still a few parts left according to `valgrind`.

- Initialize allocated space before use.
- Exit cleanlier (is that even a word?).
- Fix the menuItem copy constructor.
- Fix the menuItem destructor.