### PR TITLE
video: Update to comply with nxdk changes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@
 #include "xpadinput.h"
 
 #include <threads.h>
+#include <hal/video.c>
 
 void goToMainMenu(menuItem *mI, Renderer *r, Font &f,
                   int &listSize, int &currItem, int &prevItem, int &mMS) {
@@ -30,6 +31,8 @@ void __cdecl operator delete(void* itm) { free(itm); }
 #endif
 
 int main(void) {
+  XVideoSetMode(640,480,32,REFRESH_DEFAULT);
+
   int init = init_systems();
   int mainMenuSelection = 0;
   vector<menuItem> mainMenu;


### PR DESCRIPTION
XVideoSetMode() will be removed from XboxCRTEntry() in XboxDev/nxdk-pdclib#3.
This PR will make sure we comply with that change and can continue operating as per usual.