### PR TITLE
Backports from the thrimbornet branch

### DIFF
--- a/Includes/ftpConnection.h
+++ b/Includes/ftpConnection.h
@@ -1,10 +1,15 @@
 #ifndef __FTPCONNECTION_H
 #define __FTPCONNECTION_H
 
+// Set buffer sizes to 1KiB for commands and 64KiB for data
+// Command buffer should selldom (never?) exceed 512B but I prefer a little headroom.
+// Data buffer is bigger in order for disk writes to be quicker - writing bigger
+// chunks is usually preferable for a myriad of reasons.
+#define FTP_CMD_BUFFER_SIZE (1024)
+#define FTP_DATA_BUFFER_SIZE (64 * 1024)
+
 #include <string>
 #include "ftpServer.h"
-
-#define FTP_BUFFER_SIZE (64 * 1024)
 
 class ftpServer;
 
@@ -13,7 +18,7 @@ class ftpConnection {
   int dataFd;
   std::string pwd;
   bool logged_in;
-  char buf[FTP_BUFFER_SIZE];
+  char* buf;
   char mode;
   std::string rnfr;
 
@@ -57,8 +62,8 @@ class ftpConnection {
   
 public:
   ftpConnection(int fd, ftpServer* s);
-  void doYourThing(void);
-  void killConnection(void);
+  ~ftpConnection();
+  bool update(void);
 };
 
 #endif

--- a/Includes/ftpServer.h
+++ b/Includes/ftpServer.h
@@ -31,8 +31,8 @@ class ftpServer {
 public:
   ftpServer(int port);
   int init();
-  int run(void*);
-  void forgetMe(int fd);
+  int run();
+  void forgetConnection(int fd);
   int openConnection(std::string const& addr, std::string const& port);
 };
 

--- a/Includes/outputLine.cpp
+++ b/Includes/outputLine.cpp
@@ -19,7 +19,7 @@ void outputLine(const char* format, ...) {
   debugPrint("%s", buffer);
   OutputDebugStringA(buffer);
 #else
-  SDL_Log("%s", buffer);
+  printf("%s", buffer);
 #endif
   va_end(args);
 }

--- a/Includes/subsystems.cpp
+++ b/Includes/subsystems.cpp
@@ -17,6 +17,10 @@
 #include "networking.h"
 #endif
 
+extern "C" {
+  extern uint8_t* _fb;
+}
+
 int init_systems() {
 #ifdef NXDK
   VIDEO_MODE xmode;
@@ -24,6 +28,12 @@ int init_systems() {
   bool use_dhcp = true;
   while (XVideoListModes(&xmode, 0, 0, &p)) {}
   XVideoSetMode(xmode.width, xmode.height, xmode.bpp, xmode.refresh);
+
+  size_t fb_size = xmode.width * xmode.height * (xmode.bpp + 7) / 8;
+  _fb = (uint8_t*)MmAllocateContiguousMemoryEx(fb_size, 0, 0xFFFFFFFF, 0x1000, PAGE_READWRITE | PAGE_WRITECOMBINE);
+  memset(_fb, 0x00, fb_size);
+#define _PCRTC_START				0xFD600800
+  *(unsigned int*)(_PCRTC_START) = (unsigned int)_fb & 0x03FFFFFF;
 
   if (!nxMountDrive('C', "\\Device\\Harddisk0\\Partition2")) {
     outputLine("Mounting error: Could not mount drive C\n");


### PR DESCRIPTION
During work targeting @thrimbor's NIC driver fixes, some oddities were identified and corrected.

- The framebuffer is now allocated
- FTP connections no longer kill themselves - the FTP server kills them instead
- FTP connections now have a decent destructor
- `outputLine` no longer requires SDL in the non-nxdk build