### PR TITLE
main: Stop hogging CPU in main thread

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,8 @@
 
 #ifdef NXDK
 #include <hal/xbox.h>
+#include <hal/video.h>
+#include <windows.h>
 #endif
 
 void goToMainMenu(menuItem *mI, Renderer *r, Font &f,
@@ -257,6 +259,11 @@ int main(void) {
       default:
         break;
       }
+#ifdef NXDK
+      // Let's not hog CPU for nothing.
+      XVideoWaitForVBlank();
+      SwitchToThread();
+#endif
     }
   }
   delete s;


### PR DESCRIPTION
CPU is probably better used in other places than simply polling for input events.

Nice side effect of this change is that FTP transfer speeds skyrocketed from ~130KiB/s to ~1.3MiB/s during my (limited) testing.