### PR TITLE
networking: Timeout the DHCP server

### DIFF
--- a/Includes/networking.cpp
+++ b/Includes/networking.cpp
@@ -6,6 +6,7 @@
 #include <lwip/timeouts.h>
 #include <netif/etharp.h>
 #include <pktdrv.h>
+#include <ctime>
 
 #include "outputLine.h"
 #include "networking.h"
@@ -70,8 +71,15 @@ int setupNetwork(void* DHCP) {
   packet_timer(NULL);
 
   if (dhcp) {
+    time_t start = time(NULL);
     while (dhcp_supplied_address(g_pnetif) == 0) {
-      NtYieldExecution();
+      if((time(NULL) - start) <= 7) {
+        NtYieldExecution();
+      }
+      else {
+        outputLine("Couldn't get DHCP settings!\n");
+        break;
+      }
     }
   }
   return 0;

--- a/Includes/networking.cpp
+++ b/Includes/networking.cpp
@@ -73,13 +73,11 @@ int setupNetwork(void* DHCP) {
   if (dhcp) {
     time_t start = time(NULL);
     while (dhcp_supplied_address(g_pnetif) == 0) {
-      if((time(NULL) - start) <= 7) {
-        NtYieldExecution();
-      }
-      else {
-        outputLine("Couldn't get DHCP settings!\n");
+      if((time(NULL) - start) > 7) {
+        outputLine("Couldn't get DHCP settings!");
         break;
       }
+      NtYieldExecution();
     }
   }
   return 0;


### PR DESCRIPTION
While it isn't in the issues section, NevoX currently has an issue where in case you boot it with no internet connection, it hangs waiting for the DHCP server settings. This is caused by a line in the networking.cpp file that runs `NtYieldExecution()` while waiting. This PR adds a 7-second timeout to that loop, and it would probably be a good idea to make the given time adjustable through the config.json file. This can be implemented in a future PR.