### PR TITLE
cmake: Fix compiling and running on PC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,8 @@ endif()
 
 #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 #set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+configure_file(${CMAKE_SOURCE_DIR}/Resources/480.bmp ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/Resources/720.bmp ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/Resources/vegur.ttf ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/sampleconfig.json ${CMAKE_CURRENT_BINARY_DIR}/config.json COPYONLY)

--- a/main.cpp
+++ b/main.cpp
@@ -82,6 +82,7 @@ int main(void) {
 
     SDL_Event event;
 
+#ifdef NXDK
     ULONG ValueIndex = 0;
     ULONG Type = 0;
     uint32_t Value = 0;
@@ -102,6 +103,7 @@ int main(void) {
       lang = std::make_shared<LangMenu>(menu.getCurrentMenu(), "Language select");
       menu.setCurrentMenu(lang.get());
     }
+#endif
 
     while (running) {
       r.setDrawColor(0, 89, 0);


### PR DESCRIPTION
For some time now, NevoX hasn't been able to compile successfully on PC using CMake. This PR fixes that by using a #ifdef preprocessor directive to filter out the WinAPI code that is used only with nxdk, and also by telling the CMakeLists.txt file to copy the required files to the binary directory, which previously wasn't done, allowing NevoX to be compiled and used without any additional steps required.