### PR TITLE
Adding audio settings menu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/SDL_FontCache"]
 	path = 3rdparty/SDL_FontCache
 	url = https://github.com/grimfang4/SDL_FontCache.git
+[submodule "3rdparty/EEasyXB"]
+	path = 3rdparty/EEasyXB
+	url = git@github.com:chase-cobb/EEasyXB.git

--- a/Includes/audioMenu.cpp
+++ b/Includes/audioMenu.cpp
@@ -22,7 +22,7 @@ const char* ENABLED = "Enabled";
 const char* DISABLED = "Disabled";
 
 void AudioItem::execute(Menu *menu) {
-//#ifdef NXDK
+#ifdef NXDK
   updateEnabledState(true);
   
   std::vector<std::shared_ptr<MenuItem>> *menuItems = parentNode->getChildNodes();
@@ -35,7 +35,7 @@ void AudioItem::execute(Menu *menu) {
       thisAudioItem->setEnabledLabel(isEnabled);
     }
   }
-//#endif
+#endif
 }
 
 void AudioItem::updateEnabledState(bool toggleEnabledState) {

--- a/Includes/audioMenu.cpp
+++ b/Includes/audioMenu.cpp
@@ -1,0 +1,70 @@
+#include "audioMenu.h"
+
+#include <utility>
+#include <vector>
+#include <sstream>
+
+static 
+std::vector<std::pair<std::string, EEasyXB::AudioMode>> audioModes{
+  {"Mono", EEasyXB::AudioMode::MONO},
+  {"Stereo", EEasyXB::AudioMode::STEREO},
+  {"Surround", EEasyXB::AudioMode::SURROUND},
+  {"Surround AC3", EEasyXB::AudioMode::SURROUND_AC3},
+  {"Surround DTS", EEasyXB::AudioMode::SURROUND_DTS}};
+
+AudioItem::AudioItem(MenuNode *parent, std::string const& label, EEasyXB::AudioMode flag) :
+  MenuItem(parent, label) {
+  bitFlag = flag;
+}
+
+const char* DIVIDER = " : ";
+const char* ENABLED = "Enabled";
+const char* DISABLED = "Disabled";
+
+void AudioItem::execute(Menu *menu) {
+//#ifdef NXDK
+  updateEnabledState(true);
+  
+  std::vector<std::shared_ptr<MenuItem>> *menuItems = parentNode->getChildNodes();
+  for (auto iter = (*menuItems).begin(); iter != (*menuItems).end(); ++iter) {
+    std::shared_ptr<AudioItem> thisAudioItem = std::static_pointer_cast<AudioItem>(*iter);
+    EEasyXB::AudioMode flag = thisAudioItem->getBitFlag();
+
+    if(flag != bitFlag) {
+      bool isEnabled = EEasyXB::Eeprom::GetInstance()->IsAudioModeEnabled(flag);
+      thisAudioItem->setEnabledLabel(isEnabled);
+    }
+  }
+//#endif
+}
+
+void AudioItem::updateEnabledState(bool toggleEnabledState) {
+  EEasyXB::Eeprom* eeprom = EEasyXB::Eeprom::GetInstance();
+
+  bool activeState = eeprom->IsAudioModeEnabled(bitFlag);
+
+  if(toggleEnabledState) {
+    eeprom->SetAudioModeEnabled(bitFlag, !activeState);
+    activeState = eeprom->IsAudioModeEnabled(bitFlag);
+  }
+
+  setEnabledLabel(activeState);
+  EEasyXB::Eeprom::GetInstance()->Write();
+}
+
+void AudioItem::setEnabledLabel(bool isEnabled) {
+  std::ostringstream oss;
+  oss << DIVIDER << (isEnabled ? ENABLED : DISABLED);
+  setDynamicText(oss.str());
+}
+
+AudioMenu::AudioMenu(MenuNode *parent, std::string const& label) :
+  MenuNode(parent, label) {
+  for (auto &e: audioModes) {
+    EEasyXB::Eeprom::GetInstance()->Read();
+    bool isItemEnabled = EEasyXB::Eeprom::GetInstance()->IsAudioModeEnabled(e.second);
+    std::shared_ptr<AudioItem> newNode = std::make_shared<AudioItem>(this, e.first, e.second);
+    newNode->setEnabledLabel(isItemEnabled);
+    addNode(newNode);
+  }
+}

--- a/Includes/audioMenu.cpp
+++ b/Includes/audioMenu.cpp
@@ -9,8 +9,8 @@ std::vector<std::pair<std::string, EEasyXB::AudioMode>> audioModes{
   {"Mono", EEasyXB::AudioMode::MONO},
   {"Stereo", EEasyXB::AudioMode::STEREO},
   {"Surround", EEasyXB::AudioMode::SURROUND},
-  {"Surround AC3", EEasyXB::AudioMode::SURROUND_AC3},
-  {"Surround DTS", EEasyXB::AudioMode::SURROUND_DTS}};
+  {"AC3", EEasyXB::AudioMode::AC3},
+  {"DTS", EEasyXB::AudioMode::DTS}};
 
 AudioItem::AudioItem(MenuNode *parent, std::string const& label, EEasyXB::AudioMode flag) :
   MenuItem(parent, label) {

--- a/Includes/audioMenu.h
+++ b/Includes/audioMenu.h
@@ -2,8 +2,8 @@
 #define AUDIOMENU_H
 
 #include "menu.hpp"
-#include <string>
 #include "Eeprom.h"
+#include <string>
 
 class AudioItem : public MenuItem {
 public:

--- a/Includes/audioMenu.h
+++ b/Includes/audioMenu.h
@@ -1,0 +1,25 @@
+#ifndef AUDIOMENU_H
+#define AUDIOMENU_H
+
+#include "menu.hpp"
+#include <string>
+#include "Eeprom.h"
+
+class AudioItem : public MenuItem {
+public:
+    AudioItem(MenuNode *parent, std::string const& label, EEasyXB::AudioMode flag);
+    void execute(Menu *menu);
+    void setEnabledLabel(bool isEnabled);
+    EEasyXB::AudioMode getBitFlag()   {return bitFlag;}
+private:
+    EEasyXB::AudioMode bitFlag;
+    void updateEnabledState(bool toggleEnabledState);
+};
+
+class AudioMenu : public MenuNode {
+public:
+    AudioMenu(MenuNode *parent, std::string const& label);
+private:
+};
+
+#endif

--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -1,6 +1,7 @@
 #include "menu.hpp"
 
 #include <iostream>
+#include <sstream>
 
 #include "outputLine.h"
 #include "findXBE.h"
@@ -14,7 +15,7 @@
                                    MenuItem
 ******************************************************************************************/
 MenuItem::MenuItem(std::string const& label) : label(label) {
-
+  dynamicText = "";
 }
 
 MenuItem::MenuItem(MenuNode *parent, std::string const& label) :
@@ -30,12 +31,20 @@ std::string_view MenuItem::getLabel() const {
   return this->label;
 }
 
+std::string_view MenuItem::getDynamicText() const {
+  return this->dynamicText;
+}
+
 MenuNode *MenuItem::getParent() const {
   return parentNode;
 }
 
 void MenuItem::setParent(MenuNode* parent) {
   parentNode = parent;
+}
+
+void MenuItem::setDynamicText(std::string text) {
+  dynamicText = text;
 }
 
 /******************************************************************************************
@@ -220,6 +229,12 @@ void Menu::render(Font &font) {
        it != end(*this->currentMenu->getChildNodes());
        ++it) {
     menutext = std::string((*it)->getLabel());
+    std::string dynamictext = std::string((*it)->getDynamicText());
+    if (!dynamictext.empty()) {
+      std::ostringstream oss;
+      oss << menutext << dynamictext;
+      menutext = oss.str();
+    }
     std::pair<float, float> dimensions;
     dimensions = font.draw(menutext, coordinates);
 

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -19,11 +19,14 @@ public:
   virtual void execute(Menu *) = 0;
   MenuNode *getParent() const;
   virtual std::string_view getLabel() const;
+  std::string_view getDynamicText() const;
 
   void setParent(MenuNode* parent);
+  void setDynamicText(std::string text);
 protected:
   MenuNode *parentNode;
   const std::string label;
+  std::string dynamicText;
 };
 
 class MenuNode : public MenuItem {

--- a/Includes/settingsMenu.cpp
+++ b/Includes/settingsMenu.cpp
@@ -2,6 +2,7 @@
 #include "langMenu.hpp"
 #include "timeMenu.hpp"
 #include "wipeCache.hpp"
+#include "audioMenu.h"
 
 settingsMenu::settingsMenu(MenuNode *parent, std::string const& label) :
 MenuNode(parent, label) {
@@ -11,6 +12,7 @@ MenuNode(parent, label) {
 void settingsMenu::init() {
   addNode(std::make_shared<LangMenu>(this, "Language select"));
   addNode(std::make_shared<TimeMenu>(this, "Timezone select"));
+  addNode(std::make_shared<AudioMenu>(this, "Audio settings"));
   addNode(std::make_shared<MenuExec>("Wipe cache partitions", [](Menu *){
     wipe_cache();
   }));

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@ XBE_TITLE = NevolutionX
 INCDIR = $(CURDIR)/Includes
 RESOURCEDIR = $(CURDIR)/Resources
 
+#Store the path to the EEasyXB Source directory
+#This var is also used by the EEasyXB Makefile, and must
+#be declared.
+EEASYXB_SOURCE = $(CURDIR)/3rdparty/EEasyXB/Source
+
 SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/subsystems.cpp $(INCDIR)/findXBE.cpp \
 	$(INCDIR)/renderer.cpp $(INCDIR)/font.cpp $(INCDIR)/networking.cpp \
 	$(INCDIR)/ftpServer.cpp $(INCDIR)/ftpConnection.cpp \
 	$(INCDIR)/menu.cpp $(INCDIR)/langMenu.cpp $(INCDIR)/timeMenu.cpp \
-	$(INCDIR)/settingsMenu.cpp \
+	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp\
 	$(INCDIR)/config.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(CURDIR)/3rdparty/SDL_FontCache/SDL_FontCache.c
@@ -22,6 +27,9 @@ GEN_XISO = ${XBE_TITLE}.iso
 
 CXXFLAGS += -I$(CURDIR) -I$(INCDIR) -Wall -Wextra -std=gnu++11
 CFLAGS   += -std=gnu11
+
+#Include the Conflux Makefile to makebuild dependencies
+include $(EEASYXB_SOURCE)/Makefile
 
 new_all: copy_resources all
 


### PR DESCRIPTION
Added EEasyXB submodule and created an audio settings menu that implements the new submodule. The menu allows users to change their desired audio settings in the Xbox eeprom. 

Also made some changes in menu h/cpp to allow dynamic text in menu items. This is useful for items that can be toggled or need to present the user with text that may change with configuration.