### PR TITLE
settings: Add EEPROM query template, Audio and Video menus

### DIFF
--- a/Includes/audioMenu.cpp
+++ b/Includes/audioMenu.cpp
@@ -1,0 +1,30 @@
+#include "audioMenu.hpp"
+#include "eeprom.hpp"
+
+#include <xboxkrnl/xboxkrnl.h>
+
+audioChannelsMenuItem::audioChannelsMenuItem()
+  : switchingMenuItem("Channels", {"Stereo", "Mono", "Surround"})
+{
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex);
+  selected = Value & 0x00000003;
+  valuedLabel = "Channels: " + values.at(selected);
+}
+
+void audioChannelsMenuItem::execute(Menu *) {
+  selected = (++selected) % values.size();
+  valuedLabel = label + values.at(selected);
+
+  ULONG Type = 0;
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex, Type);
+  Value = (Value & 0xFFFFFFF0) + selected;
+  ExSaveNonVolatileSetting(valueIndex, Type, &Value, sizeof(Value));
+}
+
+audioMenu::audioMenu(MenuNode *parent, std::string const& label) :
+  MenuNode(parent, label)
+{
+  addNode(std::make_shared<audioChannelsMenuItem>());
+  addNode(std::make_shared<togglingEEPROMMenuItem>("Dolby Digital enabled: ", 0x9, 0x00010000));
+  addNode(std::make_shared<togglingEEPROMMenuItem>("DTS enabled: ", 0x9, 0x00020000));
+}

--- a/Includes/audioMenu.hpp
+++ b/Includes/audioMenu.hpp
@@ -1,0 +1,21 @@
+#ifndef __AUDIOMENU_HPP
+#define __AUDIOMENU_HPP
+
+#include "menu.hpp"
+#include "settingsMenu.hpp"
+#include <string>
+
+class audioChannelsMenuItem : public switchingMenuItem {
+private:
+  uint32_t valueIndex = 0x9;
+public:
+  audioChannelsMenuItem();
+  void execute(Menu *);
+};
+
+class audioMenu : public MenuNode {
+public:
+  audioMenu(MenuNode *parent, std::string const& label);
+};
+
+#endif

--- a/Includes/eeprom.hpp
+++ b/Includes/eeprom.hpp
@@ -1,0 +1,21 @@
+#ifndef __EEPROM_H
+#define __EEPROM_H
+
+#include <cstdint>
+#include <xboxkrnl/xboxkrnl.h>
+
+template<typename T>
+T getEEPROMValue(uint32_t valueIndex) {
+  ULONG Type = 0;
+  return getEEPROMValue<T>(valueIndex, Type);
+}
+
+template<typename T>
+T getEEPROMValue(uint32_t valueIndex, ULONG &Type) {
+  T value;
+  ULONG ResultLength = 0;
+  ExQueryNonVolatileSetting(valueIndex, &Type, &value, sizeof(value), &ResultLength);
+  return value;
+}
+
+#endif

--- a/Includes/settingsMenu.cpp
+++ b/Includes/settingsMenu.cpp
@@ -1,18 +1,67 @@
 #include "settingsMenu.hpp"
+#include "videoMenu.hpp"
+#include "audioMenu.hpp"
 #include "langMenu.hpp"
 #include "timeMenu.hpp"
 #include "wipeCache.hpp"
+#include "eeprom.hpp"
 
+#include <xboxkrnl/xboxkrnl.h>
+
+/******************************************************************************************
+ *                              switchingMenuItem
+ *****************************************************************************************/
+switchingMenuItem::switchingMenuItem(std::string const& label,
+                                     std::vector<std::string> s) :
+  MenuItem(label), values(s) {
+
+}
+
+std::string_view switchingMenuItem::getLabel() const {
+  return valuedLabel;
+}
+
+/******************************************************************************************
+ *                              togglingEEPROMMenuItem
+ *****************************************************************************************/
+togglingEEPROMMenuItem::togglingEEPROMMenuItem(std::string const& label, uint32_t vI, uint32_t bmask) :
+  MenuItem(label), bitmask(bmask), valueIndex(vI) {
+
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex);
+  value = (Value & bitmask) != 0;
+
+  valuedLabel = label + (value ? "Yes" : "No");
+}
+
+void togglingEEPROMMenuItem::execute(Menu *) {
+  value = !value;
+  valuedLabel = label + (value ? "Yes" : "No");
+
+  ULONG Type = 0;
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex, Type);
+  Value = (Value & ~bitmask) + (bitmask * value);
+  ExSaveNonVolatileSetting(valueIndex, Type, &Value, sizeof(Value));
+}
+
+std::string_view togglingEEPROMMenuItem::getLabel() const {
+  return valuedLabel;
+}
+
+/******************************************************************************************
+ *                               settingsMenu
+ *****************************************************************************************/
 settingsMenu::settingsMenu(MenuNode *parent, std::string const& label) :
 MenuNode(parent, label) {
   init();
 }
 
 void settingsMenu::init() {
+  addNode(std::make_shared<videoMenu>(this, "Video"));
+  addNode(std::make_shared<audioMenu>(this, "Audio"));
   addNode(std::make_shared<LangMenu>(this, "Language select"));
   addNode(std::make_shared<TimeMenu>(this, "Timezone select"));
   addNode(std::make_shared<MenuExec>("Wipe cache partitions", [](Menu *){
     wipe_cache();
-  }));
+  }));;
 }
 

--- a/Includes/settingsMenu.hpp
+++ b/Includes/settingsMenu.hpp
@@ -2,6 +2,29 @@
 #define __SETTINGSMENU_H
 
 #include "menu.hpp"
+#include <vector>
+#include <string>
+
+class switchingMenuItem : public MenuItem {
+protected:
+  std::vector<std::string> values;
+  std::string valuedLabel;
+  int selected;
+public:
+  switchingMenuItem(std::string const& label, std::vector<std::string>);
+  std::string_view getLabel() const;
+};
+
+class togglingEEPROMMenuItem : public MenuItem {
+  bool value = false;
+  std::string valuedLabel;
+  uint32_t bitmask;
+  uint32_t valueIndex;
+public:
+  togglingEEPROMMenuItem(std::string const& label, uint32_t vI, uint32_t bmask);
+  std::string_view getLabel() const;
+  void execute(Menu *);
+};
 
 class settingsMenu : public MenuNode {
 public:

--- a/Includes/videoMenu.cpp
+++ b/Includes/videoMenu.cpp
@@ -1,0 +1,40 @@
+#include "videoMenu.hpp"
+#include "eeprom.hpp"
+
+#include <xboxkrnl/xboxkrnl.h>
+
+static const uint32_t widescreen = 0x00010000;
+static const uint32_t letterbox = 0x00100000;
+
+static const std::vector<uint32_t> ratios = {0, widescreen, letterbox};
+
+videoRatioMenuItem::videoRatioMenuItem() :
+  switchingMenuItem("Screen Ratio: ", {"Normal", "Widescreen", "Letterbox"}) {
+
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex);
+  selected = Value & 0x00110000;
+  if (selected & widescreen) {
+    selected = 1;
+  } else if (selected & letterbox) {
+    selected = 2;
+  }
+  valuedLabel = label + values.at(selected);
+}
+
+void videoRatioMenuItem::execute(Menu *) {
+  selected = (++selected) % values.size();
+  valuedLabel = label + values.at(selected);
+
+  ULONG Type = 0;
+  uint32_t Value = getEEPROMValue<uint32_t>(valueIndex, Type);
+  Value = (Value & 0xFFEEFFFF) + ratios.at(selected);
+  ExSaveNonVolatileSetting(valueIndex, Type, &Value, sizeof(Value));
+}
+
+videoMenu::videoMenu(MenuNode *parent, std::string const& label) :
+  MenuNode(parent, label) {
+  addNode(std::make_shared<videoRatioMenuItem>());
+  addNode(std::make_shared<togglingEEPROMMenuItem>("480p: ", 0x8, 0x00080000));
+  addNode(std::make_shared<togglingEEPROMMenuItem>("720p: ", 0x8, 0x00020000));
+  addNode(std::make_shared<togglingEEPROMMenuItem>("1080i: ", 0x8, 0x00040000));
+}

--- a/Includes/videoMenu.hpp
+++ b/Includes/videoMenu.hpp
@@ -1,0 +1,21 @@
+#ifndef __VIDEOMENU_HPP
+#define __VIDEOMENU_HPP
+
+#include "menu.hpp"
+#include "settingsMenu.hpp"
+#include <string>
+
+class videoRatioMenuItem : public switchingMenuItem {
+private:
+  uint32_t valueIndex = 0x8;
+public:
+  videoRatioMenuItem();
+  void execute(Menu *);
+};
+
+class videoMenu : public MenuNode {
+public:
+  videoMenu(MenuNode *parent, std::string const& label);
+};
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/renderer.cpp $(INCDIR)/font.cpp $(INCDIR)/networking.cpp \
 	$(INCDIR)/ftpServer.cpp $(INCDIR)/ftpConnection.cpp \
 	$(INCDIR)/menu.cpp $(INCDIR)/langMenu.cpp $(INCDIR)/timeMenu.cpp \
-	$(INCDIR)/settingsMenu.cpp \
+	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp $(INCDIR)/videoMenu.cpp \
 	$(INCDIR)/config.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(CURDIR)/3rdparty/SDL_FontCache/SDL_FontCache.c

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@
 #include <SDL.h>
 
 #ifdef NXDK
+#include "eeprom.hpp"
 #include <hal/xbox.h>
 #include <hal/video.h>
 #include <windows.h>
@@ -83,25 +84,17 @@ int main(void) {
     SDL_Event event;
 
 #ifdef NXDK
-    ULONG ValueIndex = 0;
-    ULONG Type = 0;
-    uint32_t Value = 0;
-    char Value2[5] = {0};
-    ULONG ValueLength = 4;
-    ULONG ResultLength = 0;
-    ValueIndex = 0x1;
-    ExQueryNonVolatileSetting(ValueIndex, &Type, &Value2,
-                              ValueLength, &ResultLength);
-    if (ValueLength == ResultLength && Value2[0] == 0) {
+    ULONG ValueIndex = 0x1;
+    uint32_t Value = getEEPROMValue<uint32_t>(ValueIndex);
+    if (Value == 0) {
 #endif
       timeZone = std::make_shared<TimeMenu>(menu.getCurrentMenu(), "Timezone select");
       menu.setCurrentMenu(timeZone.get());
 #ifdef NXDK
     }
     ValueIndex = 0x7;
-    ExQueryNonVolatileSetting(ValueIndex, &Type, &Value,
-                              ValueLength, &ResultLength);
-    if (ValueLength == ResultLength && Value == 0) {
+    Value = getEEPROMValue<uint32_t>(ValueIndex);
+    if (Value == 0) {
 #endif
       lang = std::make_shared<LangMenu>(menu.getCurrentMenu(), "Language select");
       menu.setCurrentMenu(lang.get());


### PR DESCRIPTION
closes #64 

Slimmer EEPROM handling, simpler audio logic (could  [should?] be improved in the future).