### PR TITLE
(DRAFT) Add theme support

### DIFF
--- a/Includes/findThemes.cpp
+++ b/Includes/findThemes.cpp
@@ -1,0 +1,36 @@
+//
+// Created by kosmas on 28/7/21.
+//
+
+#include "findThemes.h"
+#include "outputLine.h"
+#ifdef NXDK
+#include <windows.h>
+#endif
+
+void findThemes(std::string const& path, MenuThemes *list) {
+  std::string workPath = path;
+  if (workPath.back() != '\\') {
+    workPath += '\\';
+  }
+  std::string searchMask = workPath + "*";
+
+  WIN32_FIND_DATA findFileData;
+  HANDLE hFind;
+  std::string tmp;
+
+  hFind = FindFirstFile(searchMask.c_str(), &findFileData);
+  if (hFind == INVALID_HANDLE_VALUE) {
+    outputLine("FindFirstHandle() failed!\n");
+  }
+
+  do {
+    if (!(findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      std::string type = path.substr(path.find(".") + 1);
+        if (type == "nevoxtheme") {
+          tmp = path + findFileData.cFileName;
+          list->addNode(std::make_shared<MenuLaunch>(findFileData.cFileName, tmp));
+        }
+   }
+  } while (FindNextFile(hFind, &findFileData) != 0);
+}

--- a/Includes/findThemes.h
+++ b/Includes/findThemes.h
@@ -1,0 +1,12 @@
+//
+// Created by kosmas on 28/7/21.
+//
+
+#ifndef NEVOLUTIONX_FINDTHEMES_H
+#define NEVOLUTIONX_FINDTHEMES_H
+
+#include "menu.hpp"
+
+void findThemes(std::string const& path, MenuThemes *list);
+
+#endif //NEVOLUTIONX_FINDTHEMES_H

--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -4,6 +4,7 @@
 
 #include "outputLine.h"
 #include "findXBE.h"
+#include "findThemes.h"
 #include "settingsMenu.hpp"
 #ifdef NXDK
 #include <hal/xbox.h>
@@ -131,6 +132,31 @@ void MenuXbe::execute(Menu *menu) {
 }
 
 /******************************************************************************************
+                                   MenuThemes
+******************************************************************************************/
+
+MenuThemes::MenuThemes(MenuNode *parent, std::string const& label, std::string const& path) :
+  MenuNode(parent, label), path(path) {
+  findThemes(path, this);
+
+}
+
+MenuThemes::~MenuThemes() {
+
+}
+
+void MenuThemes::execute(Menu *menu) {
+  if (menu->getCurrentMenu() != this) {
+    menu->setCurrentMenu(this);
+  }
+  else {
+    if (childNodes.size() > selected) {
+      this->childNodes.at(selected)->execute(menu);
+    }
+  }
+}
+
+/******************************************************************************************
                                    MenuLaunch
 ******************************************************************************************/
 MenuLaunch::MenuLaunch(std::string const& label, std::string const& path) :
@@ -188,6 +214,10 @@ Menu::Menu(const Config &config, Renderer &renderer) : renderer(renderer), rootN
     else if (!static_cast<std::string>(e["type"]).compare("settings")) {
       std::shared_ptr<MenuNode> newNode = std::make_shared<settingsMenu>(currentMenu, e["label"]);
       this->rootNode.addNode(newNode);
+    }
+    else if (!static_cast<std::string>(e["type"]).compare("themes")) {
+        std::shared_ptr<MenuThemes> newNode = std::make_shared<MenuThemes>(currentMenu, e["label"], e["path"]);
+        this->rootNode.addNode(newNode);
     }
   }
 }

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -54,6 +54,15 @@ protected:
   std::string path;
 };
 
+class MenuThemes : public MenuNode {
+public:
+  MenuThemes(MenuNode *parent, std::string const& label, std::string const& path);
+  ~MenuThemes();
+  void execute(Menu *menu);
+protected:
+    std::string path;
+};
+
 class MenuLaunch : public MenuItem {
 public:
   MenuLaunch(std::string const& label, std::string const& path);

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INCDIR = $(CURDIR)/Includes
 RESOURCEDIR = $(CURDIR)/Resources
 
 SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
-	$(INCDIR)/subsystems.cpp $(INCDIR)/findXBE.cpp \
+	$(INCDIR)/subsystems.cpp $(INCDIR)/findXBE.cpp $(INCDIR)/findThemes.cpp \
 	$(INCDIR)/renderer.cpp $(INCDIR)/font.cpp $(INCDIR)/networking.cpp \
 	$(INCDIR)/ftpServer.cpp $(INCDIR)/ftpConnection.cpp \
 	$(INCDIR)/menu.cpp $(INCDIR)/langMenu.cpp $(INCDIR)/timeMenu.cpp \

--- a/sampleconfig.json
+++ b/sampleconfig.json
@@ -43,6 +43,11 @@
         {
             "label": "Some stupid submenu",
             "type": "submenu"
+        },
+        {
+            "label": "Themes",
+            "type": "themes",
+            "path": "F:\\Themes"
         }
     ]
 }


### PR DESCRIPTION
Hello!

Theme support has been listed in the README to-do list for a while, but has never been implemented. As an exercise, I decided to make this a reality myself.

I decided to start out with just the basic code for the menu item instead of the entire thing as I predict there will be lots of things to implement and just wanted to open a PR to let people know that this is "under construction".

Currently, here's what the code does:

It can now create a "theme" type menu (like scan and settings are different types) that once launched will look at the given path for .nevoxtheme files. Unfortunately this is all for now, however I've tried to figure out the .nevoxtheme file format.

At first, I thought it'd just be a special JSON file that has a few key/value pairs:

1) 3 background image pairs, pointing to the path of a background image for 480p, 720p and 1080i.
2) A font pair, pointing to the path of a font
3) A font color pair, with a hexadecimal RGB value representing the font color.

The name could be taken from the theme file name or from a new key/value pair.

However, I decided that due to complications with paths on Xbox like D: being automounted as the XBE path and the rest not being always mounted, we can do better.

This is what I came up with:

1) An 8 bit unsigned integer holding the theme name length
2) As many chars as the integer holds containing the theme name
3) A 32 bit unsigned integer holding the size for a 480p image in bytes (This can be avoided if the file size is in the image header but I'm not sure every format has it)
4) For that number of bytes there will be the image data
5) Repeat for 720p and 1080i images
6) A 32 bit unsigned integer holding the font size in bytes (Like images, this can be avoided given the size is in the header)
7) Font data for that many bytes
8) A 32 bit unsigned integer holding the hexadecimal RGB value representing the font color

Another reason I thought of that format is ease of use. Using the first file format, that'd need us to copy 5 files to have a complete, working theme. With this format, we only need 1 big file.

A couple of disadvantages I've thought of for the 2nd format are: 

1. The code to implement it will not be trivial, however it should be possible using the SDL_RWops API.
2. Accessibility to creation tools. This will need a separate tool to create themes. We can implement one in the NevoX themes menu and also create a standalone program that can do the work.

I'm ready to hear your thoughts on both the code and the themes format. Cheers!