### PR TITLE
Adds ability to parse multiple paths per menu item.

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -9,6 +9,8 @@
 #include <hal/xbox.h>
 #endif
 
+// Character used in the config.json to separate multiple path entries.
+#define PATH_DELIMITER ','
 
 /******************************************************************************************
                                    MenuItem
@@ -106,13 +108,24 @@ void MenuNode::down() {
 /******************************************************************************************
                                    MenuXbe
 ******************************************************************************************/
-MenuXbe::MenuXbe(MenuNode *parent, std::string const& label, std::string const& path) :
-  MenuNode(parent, label), path(path) {
+MenuXbe::MenuXbe(MenuNode *parent, std::string const& label, std::string const& paths) :
+  MenuNode(parent, label) {
+  size_t path_start = 0;
+  for (size_t path_end = paths.find(PATH_DELIMITER, path_start);
+       path_end != std::string::npos;
+       path_end = paths.find(PATH_DELIMITER, path_start)) {
+    
+      std::string subpath = paths.substr(path_start, path_end - path_start);
+      findXBE(subpath, this);
+      path_start = path_end + 1;
+  }
+  std::string path = paths.substr(path_start);
+
   // Find "default.xbe"'s and add them to ChildNodes
   findXBE(path, this);
   std::sort(begin(childNodes), end(childNodes),
-            [](std::shared_ptr<MenuItem> a,
-               std::shared_ptr<MenuItem> b){ return a->getLabel() < b->getLabel();});
+            [](const std::shared_ptr<MenuItem> &a,
+               const std::shared_ptr<MenuItem> &b){ return a->getLabel() < b->getLabel();});
 }
 
 MenuXbe::~MenuXbe() {

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -46,12 +46,9 @@ protected:
 
 class MenuXbe : public MenuNode {
 public:
-  MenuXbe(std::string const& label, std::string const& path);
-  MenuXbe(MenuNode *parent, std::string const& label, std::string const& path);
+  MenuXbe(MenuNode *parent, std::string const& label, std::string const& paths);
   ~MenuXbe();
   void execute(Menu *menu);
-protected:
-  std::string path;
 };
 
 class MenuLaunch : public MenuItem {

--- a/sampleconfig.json
+++ b/sampleconfig.json
@@ -20,12 +20,12 @@
         {
             "label": "Games",
             "type": "scan",
-            "path": "F:\\Games\\"
+            "path": "F:\\Games\\,G:\\Games"
         },
         {
             "label": "Applications",
             "type": "scan",
-            "path": "F:\\Apps"
+            "path": "F:\\Apps,G:\\Apps"
         },
         {
             "label": "Launch DVD",


### PR DESCRIPTION
Adds the ability to provide comma-delimited paths instead of a single path for a `scan` item (so games across multiple partitions can go under one menu item).