### PR TITLE
Defers network initialization.

### DIFF
--- a/Includes/ftpServer.cpp
+++ b/Includes/ftpServer.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <iomanip>
 #include <algorithm>
 #include "outputLine.h"
 #include "ftpServer.h"
@@ -213,7 +211,10 @@ int ftpServer::openConnection(std::string const& addr, std::string const& port) 
   return ret;
 }
 
-int thread_runner(void* server) {
-  ftpServer* s = static_cast<ftpServer*>(server);
-  return s->run();
+void ftpServer::runAsync() {
+  serverThread = std::thread(thread_runner, this);
+}
+
+int ftpServer::thread_runner(ftpServer *server) {
+  return server->run();
 }

--- a/Includes/ftpServer.h
+++ b/Includes/ftpServer.h
@@ -1,6 +1,8 @@
 #ifndef __FTPSERVER_H
 #define __FTPSERVER_H
 
+#include <thread>
+
 #include <string>
 #include <map>
 #include "ftpConnection.h"
@@ -27,17 +29,20 @@ class ftpServer {
   socklen_t addrlen;
   struct addrinfo hints, *ai, *p;
 
+  std::thread serverThread;
+
   void* getInAddr(struct sockaddr *sa);
+  static int thread_runner(ftpServer *server);
+
 public:
   ftpServer(ftpConfig const* conf);
   int init();
   int run();
+  void runAsync();
   void forgetConnection(int fd);
   int openConnection(std::string const& addr, std::string const& port);
 
   const ftpConfig *conf;
 };
-
-int thread_runner(void* server);
 
 #endif

--- a/Includes/networkManager.cpp
+++ b/Includes/networkManager.cpp
@@ -1,0 +1,53 @@
+#include "networkManager.h"
+
+#include <utility>
+
+#ifdef NXDK
+
+#include "networking.h"
+
+extern "C" {
+extern struct netif *g_pnetif;
+}
+
+#endif
+
+NetworkManager::NetworkManager(Config config) : config(std::move(config)), status(INIT_NONE) {
+}
+
+void NetworkManager::asyncInit() {
+  assert(status == INIT_NONE);
+  init_thread = std::thread(thread_main, this);
+}
+
+void NetworkManager::thread_main(NetworkManager *manager) {
+#ifdef NXDK
+  const Config &config = manager->config;
+
+  // TODO: Retrieve from Config.
+  bool use_dhcp = true;
+
+  int status = setupNetwork(&use_dhcp);
+  if (status) {
+    manager->status = INIT_FAILED;
+  } else {
+    manager->status = INIT_SUCCEEDED;
+  }
+
+#else
+  manager->status = INIT_FAILED;
+#endif
+}
+
+std::string NetworkManager::IPAddressString() const {
+  NetworkStatus current_status = status;
+  if (current_status != INIT_SUCCEEDED && current_status != RUNNING) {
+    return std::string();
+  }
+
+  if (!g_pnetif) {
+    return std::string();
+  }
+
+  return ip4addr_ntoa(netif_ip4_addr(g_pnetif));
+}

--- a/Includes/networkManager.h
+++ b/Includes/networkManager.h
@@ -1,0 +1,45 @@
+#ifndef NEVOLUTIONX_NETWORKMANAGER_H
+#define NEVOLUTIONX_NETWORKMANAGER_H
+
+#include "config.hpp"
+
+#include <thread>
+
+class NetworkManager {
+public:
+  typedef enum {
+    INIT_NONE,
+    INIT_SUCCEEDED,
+    INIT_FAILED,
+    RUNNING
+  } NetworkStatus;
+
+  explicit NetworkManager(Config config);
+
+  // Initializes the network asynchronously.
+  void asyncInit();
+
+  inline NetworkStatus getStatus() const { return status; }
+  std::string IPAddressString() const;
+
+  inline bool isNewlyInitialized() {
+    if (status == INIT_SUCCEEDED) {
+      status = RUNNING;
+      init_thread.join();
+      return true;
+    }
+
+    return false;
+  }
+
+private:
+  static void thread_main(NetworkManager *manager);
+
+  Config config;
+
+  std::atomic<NetworkStatus> status;
+  std::thread init_thread;
+};
+
+
+#endif //NEVOLUTIONX_NETWORKMANAGER_H

--- a/Includes/networking.cpp
+++ b/Includes/networking.cpp
@@ -58,7 +58,7 @@ int setupNetwork(void* DHCP) {
   g_pnetif = netif_add(&nforce_netif, &ipaddr, &netmask, &gw,
                        NULL, nforceif_init, ethernet_input);
   if (!g_pnetif) {
-    return 1;
+    return ERR_NO_INTERFACE;
   }
   netif_set_default(g_pnetif);
   netif_set_up(g_pnetif);
@@ -75,7 +75,7 @@ int setupNetwork(void* DHCP) {
     while (dhcp_supplied_address(g_pnetif) == 0) {
       if((time(NULL) - start) > 7) {
         outputLine("Couldn't get DHCP settings!");
-        break;
+        return ERR_NO_DHCP_RESPONSE;
       }
       NtYieldExecution();
     }

--- a/Includes/networking.h
+++ b/Includes/networking.h
@@ -7,6 +7,9 @@ extern "C" {
 
 #include <lwip/netif.h>
 
+#define ERR_NO_INTERFACE 1
+#define ERR_NO_DHCP_RESPONSE 2
+
 int setupNetwork(void* DHCP);
 
 void closeNetwork();

--- a/Includes/renderer.h
+++ b/Includes/renderer.h
@@ -18,6 +18,7 @@ public:
   void flip();
 
   SDL_Renderer* getRenderer() {return renderer;}
+  int getWidth() const {return width;}
   int getHeight() const {return height;}
 
   int setDrawColor(uint8_t r = 0x40, uint8_t g = 0x40,

--- a/Includes/subsystems.cpp
+++ b/Includes/subsystems.cpp
@@ -32,7 +32,6 @@ int init_systems() {
 #ifdef NXDK
   VIDEO_MODE xmode;
   void *p = NULL;
-  bool use_dhcp = true;
   while (XVideoListModes(&xmode, 0, 0, &p)) {}
   XVideoSetMode(xmode.width, xmode.height, xmode.bpp, xmode.refresh);
 
@@ -78,12 +77,7 @@ int init_systems() {
     outputLine("TTF Init Error: %s", TTF_GetError());
     return 2;
   }
-#ifdef NXDK
-  if (setupNetwork(&use_dhcp) != 0) {
-    outputLine("Network setup failed.");
-    return 1;
-  }
-#endif
+
   if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {
     outputLine("Init error: %s", SDL_GetError());
     return 3;

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ RESOURCEDIR = $(CURDIR)/Resources
 SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/subsystems.cpp $(INCDIR)/findXBE.cpp \
 	$(INCDIR)/renderer.cpp $(INCDIR)/font.cpp $(INCDIR)/networking.cpp \
+	$(INCDIR)/networkManager.cpp \
 	$(INCDIR)/ftpServer.cpp $(INCDIR)/ftpConnection.cpp \
 	$(INCDIR)/menu.cpp $(INCDIR)/langMenu.cpp $(INCDIR)/timeMenu.cpp \
 	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp $(INCDIR)/videoMenu.cpp \

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include "timeMenu.hpp"
 #include "findXBE.h"
 #include "font.h"
+#include "networkManager.h"
 #include "outputLine.h"
 #include "renderer.h"
 #include "subsystems.h"
@@ -31,6 +32,7 @@
 #define HOME "." SEPARATOR
 #endif
 
+
 int main(void) {
 #ifdef NXDK
   mountHomeDir('A');
@@ -39,108 +41,124 @@ int main(void) {
   std::map<int, SDL_GameController*> controllers;
 
   int init = init_systems();
-  ftpServer *s = nullptr;
+  if (init) {
+      shutdown_systems(init);
+      return init;
+  }
 
-  std::thread thrF;
+  NetworkManager networkManager(config);
+  networkManager.asyncInit();
 
-  if (init <= 1) {
-    bool running = true;
+  bool running = true;
 
-    // Open our GameController
-    for (int i = 0; i < SDL_NumJoysticks(); ++i) {
-      if (SDL_IsGameController(i)) {
-        controllers[i] = SDL_GameControllerOpen(i);
-        if (!controllers[i]) {
-          outputLine("Could not open gamecontroller %i: %s\n", i, SDL_GetError());
-          SDL_Delay(2000);
-        }
+  // Open our GameController
+  for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+    if (SDL_IsGameController(i)) {
+      controllers[i] = SDL_GameControllerOpen(i);
+      if (!controllers[i]) {
+        outputLine("Could not open gamecontroller %i: %s\n", i, SDL_GetError());
+        SDL_Delay(2000);
       }
-    }
-
-    // Set a hint that we want to use our gamecontroller always
-    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-
-    if (init == 0 && config.settings.ftp.getEnabled()) {
-      s = new ftpServer(&config.settings.ftp);
-      s->init();
-      thrF = std::thread(thread_runner, s);
-    }
-
-    // Create render system
-    Renderer r;
-    r.init(HOME);
-
-    // Load font
-    // FIXME: Font path should be read from theme
-    Font f(r, HOME "vegur.ttf");
-
-    Menu menu(config, r);
-    std::shared_ptr<MenuNode> lang = nullptr;
-    std::shared_ptr<MenuNode> timeZone = nullptr;
-
-    r.drawBackground();
-    r.flip();
-
-    SDL_Event event;
-
-#ifdef NXDK
-    ULONG ValueIndex = 0x1;
-    uint32_t Value = getEEPROMValue<uint32_t>(ValueIndex);
-    if (Value == 0) {
-#endif
-      timeZone = std::make_shared<TimeMenu>(menu.getCurrentMenu(), "Timezone select");
-      menu.setCurrentMenu(timeZone.get());
-#ifdef NXDK
-    }
-    ValueIndex = 0x7;
-    Value = getEEPROMValue<uint32_t>(ValueIndex);
-    if (Value == 0) {
-#endif
-      lang = std::make_shared<LangMenu>(menu.getCurrentMenu(), "Language select");
-      menu.setCurrentMenu(lang.get());
-#ifdef NXDK
-    }
-#endif
-
-    while (running) {
-      r.setDrawColor(0, 89, 0);
-      r.clear();
-      r.drawBackground();
-
-      menu.render(f);
-      r.flip();
-      while (SDL_PollEvent(&event)) {
-        if (event.type == SDL_QUIT) {
-          running = false;
-          break;
-        } else if (event.type == SDL_CONTROLLERDEVICEADDED) {
-          controllers[event.cdevice.which] = SDL_GameControllerOpen(event.cdevice.which);
-        } else if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
-          SDL_GameControllerClose(controllers[event.cdevice.which]);
-          controllers.erase(event.cdevice.which);
-        } else if (event.type == SDL_CONTROLLERBUTTONDOWN) {
-          if (event.cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_UP) {
-            menu.up();
-          } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN) {
-            menu.down();
-          } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_A) {
-            menu.execute();
-          } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_B ||
-                     event.cbutton.button == SDL_CONTROLLER_BUTTON_BACK) {
-            menu.back();
-          }
-        }
-      }
-#ifdef NXDK
-      // Let's not hog CPU for nothing.
-      SwitchToThread();
-#endif
     }
   }
+
+  // Set a hint that we want to use our gamecontroller always
+  SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+  // Create render system
+  Renderer r;
+  r.init(HOME);
+
+  // Load font
+  // FIXME: Font path should be read from theme
+  Font f(r, HOME "vegur.ttf");
+
+  Menu menu(config, r);
+  std::shared_ptr<MenuNode> lang = nullptr;
+  std::shared_ptr<MenuNode> timeZone = nullptr;
+
+  r.drawBackground();
+  r.flip();
+
+  SDL_Event event;
+
+#ifdef NXDK
+  ULONG ValueIndex = 0x1;
+  uint32_t Value = getEEPROMValue<uint32_t>(ValueIndex);
+  if (Value == 0) {
+#endif
+    timeZone = std::make_shared<TimeMenu>(menu.getCurrentMenu(), "Timezone select");
+    menu.setCurrentMenu(timeZone.get());
+#ifdef NXDK
+  }
+  ValueIndex = 0x7;
+  Value = getEEPROMValue<uint32_t>(ValueIndex);
+  if (Value == 0) {
+#endif
+    lang = std::make_shared<LangMenu>(menu.getCurrentMenu(), "Language select");
+    menu.setCurrentMenu(lang.get());
+#ifdef NXDK
+  }
+#endif
+
+  int info_x = static_cast<int>(r.getWidth() * 0.70);
+  int info_y = static_cast<int>(r.getHeight() * 0.85);
+  std::pair<float, float> info_coordinates(info_x, info_y);
+
+  ftpServer *ftpServerInstance = nullptr;
+  while (running) {
+    if (config.settings.ftp.getEnabled() && networkManager.isNewlyInitialized()) {
+      ftpServerInstance = new ftpServer(&config.settings.ftp);
+      ftpServerInstance->init();
+      ftpServerInstance->runAsync();
+    }
+
+    r.setDrawColor(0, 89, 0);
+    r.clear();
+    r.drawBackground();
+
+    menu.render(f);
+
+    std::string ip_address = networkManager.IPAddressString();
+    f.draw(ip_address, info_coordinates);
+
+    r.flip();
+
+    while (SDL_PollEvent(&event)) {
+      if (event.type == SDL_QUIT) {
+        running = false;
+        break;
+      } else if (event.type == SDL_CONTROLLERDEVICEADDED) {
+        controllers[event.cdevice.which] = SDL_GameControllerOpen(event.cdevice.which);
+      } else if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
+        SDL_GameControllerClose(controllers[event.cdevice.which]);
+        controllers.erase(event.cdevice.which);
+      } else if (event.type == SDL_CONTROLLERBUTTONDOWN) {
+        if (event.cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_UP) {
+          menu.up();
+        } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN) {
+          menu.down();
+        } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_A) {
+          menu.execute();
+        } else if (event.cbutton.button == SDL_CONTROLLER_BUTTON_B ||
+                   event.cbutton.button == SDL_CONTROLLER_BUTTON_BACK) {
+          menu.back();
+        }
+      }
+    }
+
+#ifdef NXDK
+    // Let's not hog CPU for nothing.
+    SwitchToThread();
+#endif
+  }
+
   for (auto c: controllers) {
     SDL_GameControllerClose(c.second);
   }
-  delete s;
+
+  delete ftpServerInstance;
+
   shutdown_systems(init);
   return init;
 }


### PR DESCRIPTION
-  Switches init of the network and network-dependent services to a background thread so a slow DHCP response does not stall entry into the dashboard.
- Adds rendering of the current IP address as an indication that the network is running.
- Simplifies handling of subsystem init failure in `main.cpp` to reduce indentation of the main loop.
