### PR TITLE
Adds fallback name for XBEs without full cert headers.

### DIFF
--- a/Includes/findXBE.cpp
+++ b/Includes/findXBE.cpp
@@ -60,6 +60,12 @@ int findXBE(std::string const& path, MenuXbe *list) {
           }
           ++offset;
         }
+
+        // Some homebrew content may not have a name in the certification
+        // header, so fallback to using the path as the name.
+        if (!strlen(xbeName)) {
+          strncpy(xbeName, fData.cFileName, sizeof(xbeName) - 1);
+        }
         list->addNode(std::make_shared<MenuLaunch>(xbeName, tmp));
         fclose(tmpFILE);
         tmpFILE = nullptr;


### PR DESCRIPTION
Came across some XBEs that do not have any `xbeName` info in the certification header. This change uses the dirname of the `default.xbe` to avoid blank entries in the menu.