### PR TITLE
Adds log overlay

### DIFF
--- a/Includes/infoLog.cpp
+++ b/Includes/infoLog.cpp
@@ -1,0 +1,92 @@
+#include "infoLog.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+#ifdef NXDK
+#include <windows.h>
+#include <hal/debug.h>
+#else
+#include <SDL.h>
+#endif
+
+InfoLog *InfoLog::singleton = nullptr;
+
+InfoLog *InfoLog::getInstance() {
+  if (!singleton) {
+    singleton = new InfoLog();
+  }
+
+  return singleton;
+}
+
+void InfoLog::outputLine(std::string const& line) {
+  OutputDebugStringA(line.c_str());
+
+  if (isOutputCaptured()) {
+    InfoLog::getInstance()->addLine(line);
+  } else {
+#ifdef NXDK
+    debugPrint("%s", line.c_str());
+#else
+    printf("%s", line.c_str());
+#endif
+  }
+}
+
+void InfoLog::outputLine(const char* format, ...) {
+  char buffer[4096];
+  va_list args;
+  va_start(args, format);
+  vsprintf(buffer, format, args);
+
+  outputLine(std::string(buffer));
+
+  va_end(args);
+}
+
+void InfoLog::addLine(const std::string &line) {
+  std::lock_guard<std::mutex> lock(logMutex);
+  log.push_back(line);
+
+  overlayLog.emplace_back(line, framesPerOverlayItem);
+}
+
+void InfoLog::renderAsOverlay(Renderer &r, Font &font) {
+  // TODO: Consider centralizing definition of the renderer safe area.
+  auto displayWidth = static_cast<float>(r.getWidth()) * 0.8f;
+  auto startWidth = static_cast<float>(r.getWidth()) * 0.1f;
+  auto displayHeight = static_cast<float>(r.getHeight()) * 0.9f;
+  auto startHeight = static_cast<float>(r.getHeight()) * 0.1f;
+
+  float bottom = displayHeight + startHeight;
+
+  std::list<std::pair<std::string, float>> reversedOutput;
+  for (auto it = begin(overlayLog), itEnd = end(overlayLog); it != itEnd; ) {
+    auto &item = *it;
+
+    const std::string &line = item.first;
+    auto lineHeight = font.getColumnHeight(line, displayWidth);
+    reversedOutput.push_front(std::make_pair(line, lineHeight));
+
+    if (!--item.second) {
+      it = overlayLog.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+
+  r.setDrawColor(overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+  for (auto const& item : reversedOutput) {
+    auto itemHeight = item.second;
+    bottom -= itemHeight;
+    if (bottom < startHeight) {
+      break;
+    }
+
+    SDL_FRect backgroundArea{startWidth, bottom, displayWidth, itemHeight};
+    r.fillRectangle(backgroundArea);
+    font.drawColumn(item.first, std::make_pair(startWidth, bottom), displayWidth);
+  }
+}

--- a/Includes/infoLog.h
+++ b/Includes/infoLog.h
@@ -1,0 +1,51 @@
+#ifndef NEVOLUTIONX_INCLUDES_INFOLOG_H_
+#define NEVOLUTIONX_INCLUDES_INFOLOG_H_
+
+#include <list>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "font.h"
+#include "renderer.h"
+
+class InfoLog {
+public:
+  static void capture() { getInstance()->captured = true; }
+
+  static void outputLine(const char* format, ...);
+  static void outputLine(std::string const& line);
+
+  static bool isOutputCaptured() { return getInstance()->captured; }
+
+  static void renderOverlay(Renderer &r, Font &font) {
+    getInstance()->renderAsOverlay(r, font);
+  }
+
+private:
+  // Tuple of string, frames remaining.
+  typedef std::pair<std::string, int> OverlayItem;
+
+  static InfoLog *getInstance();
+
+  InfoLog() = default;
+  void addLine(std::string const& line);
+  void renderAsOverlay(Renderer &r, Font &font);
+
+  static InfoLog *singleton;
+
+  // The number of frames to display an overlay log entry before hiding it.
+  int framesPerOverlayItem{30};
+
+  uint8_t overlayRed{0};
+  uint8_t overlayGreen{0};
+  uint8_t overlayBlue{0};
+  uint8_t overlayAlpha{140};
+  
+  std::atomic<bool> captured{false};
+  std::mutex logMutex;
+  std::list<std::string> log;
+  std::list<OverlayItem> overlayLog;
+};
+
+#endif //NEVOLUTIONX_INCLUDES_INFOLOG_H_

--- a/Includes/outputLine.cpp
+++ b/Includes/outputLine.cpp
@@ -10,16 +10,24 @@
 #include <SDL.h>
 #endif
 
+#include "infoLog.h"
+
 void outputLine(const char* format, ...) {
   char buffer[4096];
   va_list args;
   va_start(args, format);
   vsprintf(buffer, format, args);
+
+  if (InfoLog::isOutputCaptured()) {
+    InfoLog::outputLine(buffer);
+  } else {
 #ifdef NXDK
-  debugPrint("%s", buffer);
-  OutputDebugStringA(buffer);
+    debugPrint("%s", buffer);
+    OutputDebugStringA(buffer);
 #else
-  printf("%s", buffer);
+    printf("%s", buffer);
 #endif
+  }
+
   va_end(args);
 }

--- a/Includes/renderer.cpp
+++ b/Includes/renderer.cpp
@@ -117,6 +117,14 @@ void Renderer::drawTexture(SDL_Texture* tex, int x, int y) {
   drawTexture(tex, dst);
 }
 
+void Renderer::fillRectangle(const SDL_Rect &dst) {
+  SDL_RenderFillRect(renderer, &dst);
+}
+
+void Renderer::fillRectangle(const SDL_FRect &dst) {
+  SDL_RenderFillRectF(renderer, &dst);
+}
+
 void Renderer::blitSurface(SDL_Surface* bg, SDL_Surface* fg, int offset) {
   SDL_Rect dst = {offset, offset, fg->w, fg->h};
   SDL_SetSurfaceBlendMode(fg, SDL_BLENDMODE_BLEND);

--- a/Includes/renderer.h
+++ b/Includes/renderer.h
@@ -28,6 +28,9 @@ public:
   void drawTexture(SDL_Texture* tex, SDL_Rect &dst);
   void drawTexture(SDL_Texture* tex, int x, int y);
 
+  void fillRectangle(const SDL_Rect &dst);
+  void fillRectangle(const SDL_FRect &dst);
+
   void blitSurface(SDL_Surface* bg, SDL_Surface* fg, int offset);
 
   void drawBackground();

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/ftpServer.cpp $(INCDIR)/ftpConnection.cpp \
 	$(INCDIR)/menu.cpp $(INCDIR)/langMenu.cpp $(INCDIR)/timeMenu.cpp \
 	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp $(INCDIR)/videoMenu.cpp \
+	$(INCDIR)/infoLog.cpp \
 	$(INCDIR)/config.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(CURDIR)/3rdparty/SDL_FontCache/SDL_FontCache.c

--- a/main.cpp
+++ b/main.cpp
@@ -3,8 +3,8 @@
 #include "menu.hpp"
 #include "langMenu.hpp"
 #include "timeMenu.hpp"
-#include "findXBE.h"
 #include "font.h"
+#include "infoLog.h"
 #include "networkManager.h"
 #include "outputLine.h"
 #include "renderer.h"
@@ -82,6 +82,8 @@ int main(void) {
   r.drawBackground();
   r.flip();
 
+  InfoLog::capture();
+
   SDL_Event event;
 
 #ifdef NXDK
@@ -123,6 +125,8 @@ int main(void) {
 
     std::string ip_address = networkManager.IPAddressString();
     f.draw(ip_address, info_coordinates);
+
+    InfoLog::renderOverlay(r, f);
 
     r.flip();
 


### PR DESCRIPTION
This PR adds a simple logging overlay that intercepts `outputLine` invocations and displays them on top of rendered content until some timeout elapses (30 frames by default).

Followup enhancements:
- Make the functionality configurable; for non-devs some or most of the `outputLine` info is probably not interesting and it might be useful to modify the background color of the overlay once theming is implemented.
- Provide full log rendering w/ scrolling
- Put a cap on the log size

This is a screenshot of me entering and exiting the first menu item a few times to generate some log text.
<img width="1020" alt="Screen Shot 2021-09-18 at 13 56 14" src="https://user-images.githubusercontent.com/448413/133908408-0246a9a6-81eb-45a4-9c10-27d0b89fc585.png">


