### PR TITLE
Adds subapprouter

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -359,11 +359,11 @@ void Menu::setCurrentMenu(MenuNode *menu) {
   currentMenu = menu;
 }
 
-void Menu::up() {
+void Menu::onUpPressed() {
   currentMenu->up();
 }
 
-void Menu::down() {
+void Menu::onDownPressed() {
   currentMenu->down();
 }
 

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -3,6 +3,7 @@
 
 #include "config.hpp"
 #include "font.h"
+#include "subApp.h"
 #include "xbeScanner.h"
 
 #include <list>
@@ -93,15 +94,22 @@ public:
   void (*action)(Menu *);
 };
 
-class Menu {
+class Menu : public SubApp {
 public:
   Menu(const Config &config, Renderer &renderer);
-  void render(Font &font);
+  void render(Font &font) override;
   MenuNode *getCurrentMenu();
   void setCurrentMenu(MenuNode *);
 
-  void up();
-  void down();
+  void onUpPressed() override;
+  void onDownPressed() override;
+  void onLeftPressed() override { pageUp(); }
+  void onRightPressed() override { pageDown(); }
+  void onAPressed() override { execute(); }
+  void onStartPressed() override { execute();  }
+  void onBackPressed() override { back(); }
+  void onBPressed() override { back(); }
+
   void pageUp();
   void pageDown();
   void back();

--- a/Includes/subApp.h
+++ b/Includes/subApp.h
@@ -1,0 +1,66 @@
+#ifndef NEVOLUTIONX_INCLUDES_SUBAPP_H_
+#define NEVOLUTIONX_INCLUDES_SUBAPP_H_
+
+#include "font.h"
+
+class SubApp {
+public:
+  virtual ~SubApp() = default;
+
+  virtual void render(Font &font) = 0;
+
+  inline void setActivePlayerID(int val) { activePlayerID = val; }
+
+  // Invoked when this handler becomes the active input handler.
+  virtual void onFocus() {}
+  // Invoked when this handler becomes inactive.
+  virtual void onBlur() {}
+
+  // DPAD up
+  virtual void onUpPressed() {}
+  virtual void onUpReleased() {}
+
+  // DPAD down
+  virtual void onDownPressed() {}
+  virtual void onDownReleased() {}
+
+  // DPAD left
+  virtual void onLeftPressed() {}
+  virtual void onLeftReleased() {}
+
+  // DPAD right
+  virtual void onRightPressed() {}
+  virtual void onRightReleased() {}
+
+  virtual void onLeftStickPressed() {}
+  virtual void onLeftStickReleased() {}
+  virtual void onRightStickPressed() {}
+  virtual void onRightStickReleased() {}
+
+  virtual void onBackPressed() {}
+  virtual void onBackReleased() {}
+  virtual void onStartPressed() {}
+  virtual void onStartReleased() {}
+
+  virtual void onAPressed() {}
+  virtual void onAReleased() {}
+  virtual void onBPressed() {}
+  virtual void onBReleased() {}
+  virtual void onXPressed() {}
+  virtual void onXReleased() {}
+  virtual void onYPressed() {}
+  virtual void onYReleased() {}
+  virtual void onWhitePressed() {}
+  virtual void onWhiteReleased() {}
+  virtual void onBlackPressed() {}
+  virtual void onBlackReleased() {}
+
+protected:
+  // The contextual index of the gamepad that spawned the event being handled.
+  //
+  // This value is only relevant in the scope of one of the event handlers and
+  // is undefined otherwise.
+  int activePlayerID{-1};
+};
+
+#endif //NEVOLUTIONX_INCLUDES_SUBAPP_H_

--- a/Includes/subAppRouter.cpp
+++ b/Includes/subAppRouter.cpp
@@ -1,0 +1,154 @@
+#include "subAppRouter.h"
+
+#include "outputLine.h"
+
+SubAppRouter *SubAppRouter::singleton = nullptr;
+
+SubAppRouter *SubAppRouter::getInstance() {
+  if (!singleton) {
+    singleton = new SubAppRouter();
+  }
+  return singleton;
+}
+
+static int getPlayerIndex(SDL_JoystickID id) {
+  return SDL_JoystickGetPlayerIndex(SDL_JoystickFromInstanceID(id));
+}
+
+void SubAppRouter::push(const std::shared_ptr<SubApp>& app) {
+  if (!subAppStack.empty()) {
+    subAppStack.top()->onBlur();
+  }
+  subAppStack.push(app);
+  app->onFocus();
+}
+
+void SubAppRouter::pop() {
+  if (subAppStack.size() == 1) {
+    outputLine("Attempt to pop only SubApp, ignoring...");
+    return;
+  }
+
+  subAppStack.top()->onBlur();
+  subAppStack.pop();
+  subAppStack.top()->onFocus();
+}
+
+void SubAppRouter::render(Font &font) {
+  assert(!subAppStack.empty());
+  std::shared_ptr<SubApp> ref = subAppStack.top();
+  SubApp &app = *ref;
+  app.render(font);
+}
+
+void SubAppRouter::handleAxisMotion(const SDL_ControllerAxisEvent &event) {
+  assert(!subAppStack.empty());
+  std::shared_ptr<SubApp> ref = subAppStack.top();
+  SubApp &app = *ref;
+  app.setActivePlayerID(getPlayerIndex(event.which));
+  // TODO: Translate axis events.
+}
+
+void SubAppRouter::handleButtonDown(const SDL_ControllerButtonEvent &event) {
+  assert(!subAppStack.empty());
+  std::shared_ptr<SubApp> ref = subAppStack.top();
+  SubApp &app = *ref;
+  app.setActivePlayerID(getPlayerIndex(event.which));
+
+  switch (event.button) {
+    case SDL_CONTROLLER_BUTTON_DPAD_UP:
+      app.onUpPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+      app.onDownPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+      app.onLeftPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+      app.onRightPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+      app.onLeftStickPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+      app.onRightStickPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_A:
+      app.onAPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_B:
+      app.onBPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_X:
+      app.onXPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_Y:
+      app.onYPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+      app.onWhitePressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+      app.onBlackPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_BACK:
+      app.onBackPressed();
+      break;
+    case SDL_CONTROLLER_BUTTON_START:
+      app.onStartPressed();
+      break;
+  }
+}
+
+void SubAppRouter::handleButtonUp(const SDL_ControllerButtonEvent &event) {
+  assert(!subAppStack.empty());
+  std::shared_ptr<SubApp> ref = subAppStack.top();
+  SubApp &app = *ref;
+  app.setActivePlayerID(getPlayerIndex(event.which));
+
+  switch (event.button) {
+    case SDL_CONTROLLER_BUTTON_DPAD_UP:
+      app.onUpReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+      app.onDownReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+      app.onLeftReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+      app.onRightReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+      app.onLeftStickReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+      app.onRightStickReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_A:
+      app.onAReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_B:
+      app.onBReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_X:
+      app.onXReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_Y:
+      app.onYReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+      app.onWhiteReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+      app.onBlackReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_BACK:
+      app.onBackReleased();
+      break;
+    case SDL_CONTROLLER_BUTTON_START:
+      app.onStartReleased();
+      break;
+  }
+}

--- a/Includes/subAppRouter.h
+++ b/Includes/subAppRouter.h
@@ -1,0 +1,34 @@
+#ifndef NEVOLUTIONX_INCLUDES_SUBAPPROUTER_H_
+#define NEVOLUTIONX_INCLUDES_SUBAPPROUTER_H_
+
+#include <stack>
+
+#include <SDL.h>
+
+#include "font.h"
+#include "subApp.h"
+
+// Provides simple stack-based input and display routing.
+//
+// Maintains a stack of SubApp instances and routes rendering requests and
+// input events to the topmost SubApp.
+class SubAppRouter {
+public:
+  static SubAppRouter *getInstance();
+
+  void push(const std::shared_ptr<SubApp>&);
+  void pop();
+
+  void render(Font &font);
+
+  void handleAxisMotion(const SDL_ControllerAxisEvent &event);
+  void handleButtonDown(const SDL_ControllerButtonEvent &event);
+  void handleButtonUp(const SDL_ControllerButtonEvent &event);
+
+private:
+  static SubAppRouter *singleton;
+
+  std::stack<std::shared_ptr<SubApp>> subAppStack;
+};
+
+#endif //NEVOLUTIONX_INCLUDES_SUBAPPROUTER_H_

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp $(INCDIR)/videoMenu.cpp \
 	$(INCDIR)/infoLog.cpp \
 	$(INCDIR)/config.cpp \
+	$(INCDIR)/subAppRouter.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(INCDIR)/xbeScanner.cpp \
 	$(CURDIR)/3rdparty/SDL_FontCache/SDL_FontCache.c


### PR DESCRIPTION
This PR adds a notion of subapplications in preparation for adding a full page log viewer.

A SubApp is simply a handler for rendering and controller input. `Menu` is currently the only (and base) sub app, the router allows replacements for the menu to be pushed over the menu so they can handle input in different ways.

This should also pave the way for things like having an in-dash editor (popping a virtual keyboard) or a grid-based XBE launcher as an alternative to the menu list.