### PR TITLE
Adds button repeating

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -299,6 +299,10 @@ Menu::Menu(const Config &config, Renderer &renderer) : renderer(renderer), rootN
       this->rootNode.addNode(newNode);
     }
   }
+
+  // TODO: Take the repeat interval from the config.
+  autoRepeatIntervals[SDL_CONTROLLER_BUTTON_DPAD_UP] = 250;
+  autoRepeatIntervals[SDL_CONTROLLER_BUTTON_DPAD_DOWN] = 250;
 }
 
 void Menu::render(Font &font) {

--- a/Includes/subApp.h
+++ b/Includes/subApp.h
@@ -1,6 +1,9 @@
 #ifndef NEVOLUTIONX_INCLUDES_SUBAPP_H_
 #define NEVOLUTIONX_INCLUDES_SUBAPP_H_
 
+#include <map>
+#include <SDL.h>
+
 #include "font.h"
 
 class SubApp {
@@ -10,6 +13,7 @@ public:
   virtual void render(Font &font) = 0;
 
   inline void setActivePlayerID(int val) { activePlayerID = val; }
+  inline void setRepeatEvent(bool val) { isRepeatEvent = val; }
 
   // Invoked when this handler becomes the active input handler.
   virtual void onFocus() {}
@@ -55,12 +59,28 @@ public:
   virtual void onBlackPressed() {}
   virtual void onBlackReleased() {}
 
+  int getAutoRepeatInterval(SDL_GameControllerButton button) const {
+    auto it = autoRepeatIntervals.find(button);
+    if (it == autoRepeatIntervals.end()) {
+      return 0;
+    }
+    return it->second;
+  }
+
 protected:
   // The contextual index of the gamepad that spawned the event being handled.
   //
-  // This value is only relevant in the scope of one of the event handlers and
-  // is undefined otherwise.
+  // This value is only relevant in the scope of one of the event handlers and is undefined otherwise.
   int activePlayerID{-1};
+
+  // Set to true if the event being handled was spawned due to a button being held down.
+  //
+  // This value is only relevant in the scope of one of the event handlers and is undefined otherwise.
+  bool isRepeatEvent{false};
+
+  // Map of {button ID, repeat interval milliseconds} identifying buttons that will automatically generate repeated
+  // Pressed/Released messages while being held down.
+  std::map<SDL_GameControllerButton, int> autoRepeatIntervals;
 };
 
 #endif //NEVOLUTIONX_INCLUDES_SUBAPP_H_

--- a/Includes/subAppRouter.h
+++ b/Includes/subAppRouter.h
@@ -4,6 +4,7 @@
 #include <stack>
 
 #include <SDL.h>
+#include <windows.h>
 
 #include "font.h"
 #include "subApp.h"
@@ -27,8 +28,16 @@ public:
 
 private:
   static SubAppRouter *singleton;
+  SubAppRouter();
+  void processButtonRepeatEvents();
 
   std::stack<std::shared_ptr<SubApp>> subAppStack;
+  LONGLONG ticksPerMillisecond;
+  LONGLONG lastFrameStartTicks;
+
+  // Maps {(PlayerID, Button), timestamp} to track when virtual button press events should be fired while a button is
+  // held down.
+  std::map<std::pair<int, SDL_GameControllerButton>, LONGLONG> buttonRepeatTimers;
 };
 
 #endif //NEVOLUTIONX_INCLUDES_SUBAPPROUTER_H_

--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,7 @@ int main(void) {
   // FIXME: Font path should be read from theme
   Font f(r, HOME "vegur.ttf");
 
-  SubAppRouter router;
+  SubAppRouter &router = *SubAppRouter::getInstance();
 
   auto menu = std::make_shared<Menu>(config, r);
   router.push(menu);
@@ -113,6 +113,7 @@ int main(void) {
   std::pair<float, float> info_coordinates(info_x, info_y);
 
   ftpServer *ftpServerInstance = nullptr;
+
   while (running) {
     if (config.settings.ftp.getEnabled() && networkManager.isNewlyInitialized()) {
       ftpServerInstance = new ftpServer(&config.settings.ftp);


### PR DESCRIPTION
Allows `SubApp` instances to opt in to having buttons repeat while being held down (e.g., menus can now be scrolled by holding down the up/down buttons rather than having to tap for each item).

If the input handling changes get merged we can add a followup to make the repeat interval configurable.