### PR TITLE
Adds fullscreen log viewer

### DIFF
--- a/Includes/infoLog.cpp
+++ b/Includes/infoLog.cpp
@@ -90,7 +90,6 @@ void InfoLog::renderAsOverlay(Renderer &r, Font &font) {
     }
   }
 
-
   r.setDrawColor(overlayRed, overlayGreen, overlayBlue, overlayAlpha);
   for (auto const& item : reversedOutput) {
     auto itemHeight = item.second;
@@ -103,4 +102,19 @@ void InfoLog::renderAsOverlay(Renderer &r, Font &font) {
     r.fillRectangle(backgroundArea);
     font.drawColumn(item.first, std::make_pair(startWidth, bottom), displayWidth);
   }
+}
+
+int InfoLog::getLogSize() {
+  InfoLog &infoLog = *getInstance();
+
+  std::lock_guard<std::mutex> lock(infoLog.logMutex);
+  return static_cast<int>(infoLog.log.size());
+}
+
+std::mutex &InfoLog::getLogMutex() {
+  return getInstance()->logMutex;
+}
+
+const std::list<std::string> &InfoLog::getLog() {
+  return getInstance()->log;
 }

--- a/Includes/infoLog.h
+++ b/Includes/infoLog.h
@@ -24,6 +24,10 @@ public:
     getInstance()->renderAsOverlay(r, font);
   }
 
+  static int getLogSize();
+  static std::mutex &getLogMutex();
+  static const std::list<std::string> &getLog();
+
 private:
   // Tuple of string, frames remaining.
   typedef std::pair<std::string, int> OverlayItem;

--- a/Includes/logViewer.cpp
+++ b/Includes/logViewer.cpp
@@ -1,0 +1,83 @@
+#include "logViewer.h"
+
+#include <iterator>
+
+#include "infoLog.h"
+#include "subAppRouter.h"
+
+// Dummy index indicating that the log should always show the most recent
+// message at the bottom of the screen.
+#define LOG_INDEX_PINNED_BOTTOM   -1
+
+logViewer::logViewer(Renderer &r): renderer(r) {
+  auto w = static_cast<float>(renderer.getWidth());
+  auto h = static_cast<float>(renderer.getHeight());
+  renderArea.x = w * 0.1f;
+  renderArea.y = h * 0.05f;
+  renderArea.w = w - (renderArea.x * 2.0f);
+  renderArea.h = h - (renderArea.y * 2.0f);
+
+  endIndex = LOG_INDEX_PINNED_BOTTOM;
+}
+
+
+void logViewer::render(Font &font) {
+  renderer.setDrawColor(0, 0, 0, 0x70);
+  renderer.fillRectangle(renderArea);
+
+  float bottom = renderArea.y + renderArea.h;
+  {
+    std::lock_guard<std::mutex> lock(InfoLog::getLogMutex());
+    const std::list<std::string> &log = InfoLog::getLog();
+
+    auto it = log.rbegin();
+    auto itEnd = log.rend();
+
+    if (endIndex != LOG_INDEX_PINNED_BOTTOM) {
+      int lastIndex = static_cast<int>(log.size()) - 1;
+      for (int i = 0; it != itEnd && i < (lastIndex - endIndex); ++i, ++it) {
+        // Skip offscreen items.
+      }
+    }
+
+    for (; it != itEnd; ++it) {
+      const std::string &line = *it;
+
+      auto lineHeight = font.getColumnHeight(line, renderArea.w);
+      bottom -= lineHeight;
+
+      if (bottom < renderArea.y) {
+        // TODO: Support partial lines via clipping.
+        break;
+      }
+
+      auto coordinates = std::make_pair(renderArea.x, bottom);
+      font.drawColumn(line, coordinates, renderArea.w);
+    }
+  }
+}
+
+void logViewer::scroll(int delta) {
+  int logSize = InfoLog::getLogSize();
+  int lastIndex = logSize - 1;
+
+  if (endIndex == LOG_INDEX_PINNED_BOTTOM) {
+    if (delta > 0) {
+      return;
+    }
+    endIndex = lastIndex;
+  }
+
+  endIndex += delta;
+  if (endIndex < 0) {
+    endIndex = 0;
+  } else if (endIndex > lastIndex) {
+    // An attempt to move past the bottom of the list will trigger automatic
+    // scrolling if new messages are received.
+    endIndex = LOG_INDEX_PINNED_BOTTOM;
+  }
+}
+
+void logViewer::quit() {
+  SubAppRouter::getInstance()->pop();
+}

--- a/Includes/logViewer.h
+++ b/Includes/logViewer.h
@@ -1,0 +1,30 @@
+#ifndef NEVOLUTIONX_INCLUDES_LOGVIEWER_H_
+#define NEVOLUTIONX_INCLUDES_LOGVIEWER_H_
+
+#include <SDL.h>
+
+#include "renderer.h"
+#include "subApp.h"
+
+class logViewer : public SubApp {
+public:
+  explicit logViewer(Renderer &r);
+
+  void render(Font &font) override;
+
+  void onUpPressed() override { scroll(-1); };
+  void onDownPressed() override { scroll(1); }
+  void onBackPressed() override { quit(); }
+  void onBPressed() override { quit(); }
+
+private:
+  void scroll(int delta);
+  void quit();
+
+  int endIndex;
+
+  Renderer &renderer;
+  SDL_FRect renderArea;
+};
+
+#endif //NEVOLUTIONX_INCLUDES_LOGVIEWER_H_

--- a/Includes/logViewerMenu.cpp
+++ b/Includes/logViewerMenu.cpp
@@ -1,0 +1,11 @@
+#include "logViewerMenu.h"
+
+#include "logViewer.h"
+#include "subAppRouter.h"
+
+logViewerMenu::logViewerMenu(MenuNode *parent, const std::string &label) : MenuItem(parent, label) {
+}
+
+void logViewerMenu::execute(Menu *m) {
+  SubAppRouter::getInstance()->push(std::make_shared<logViewer>(m->getRenderer()));
+}

--- a/Includes/logViewerMenu.h
+++ b/Includes/logViewerMenu.h
@@ -1,0 +1,13 @@
+#ifndef NEVOLUTIONX_INCLUDES_LOGVIEWERMENU_H_
+#define NEVOLUTIONX_INCLUDES_LOGVIEWERMENU_H_
+
+#include "menu.hpp"
+
+class logViewerMenu : public MenuItem {
+public:
+  logViewerMenu(MenuNode *parent, std::string const& label);
+
+  void execute(Menu *) override;
+};
+
+#endif //NEVOLUTIONX_INCLUDES_LOGVIEWERMENU_H_

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -101,6 +101,8 @@ public:
   MenuNode *getCurrentMenu();
   void setCurrentMenu(MenuNode *);
 
+  inline Renderer &getRenderer() { return renderer; }
+
   void onUpPressed() override;
   void onDownPressed() override;
   void onLeftPressed() override { pageUp(); }

--- a/Includes/outputLine.cpp
+++ b/Includes/outputLine.cpp
@@ -18,9 +18,8 @@ void outputLine(const char* format, ...) {
   va_start(args, format);
   vsprintf(buffer, format, args);
 
-  if (InfoLog::isOutputCaptured()) {
-    InfoLog::outputLine(buffer);
-  } else {
+  InfoLog::outputLine(buffer);
+  if (!InfoLog::isOutputCaptured()) {
 #ifdef NXDK
     debugPrint("%s", buffer);
     OutputDebugStringA(buffer);

--- a/Includes/settingsMenu.cpp
+++ b/Includes/settingsMenu.cpp
@@ -2,6 +2,7 @@
 #include "videoMenu.hpp"
 #include "audioMenu.hpp"
 #include "langMenu.hpp"
+#include "logViewerMenu.h"
 #include "timeMenu.hpp"
 #include "wipeCache.hpp"
 #include "eeprom.hpp"
@@ -60,6 +61,7 @@ void settingsMenu::init() {
   addNode(std::make_shared<audioMenu>(this, "Audio"));
   addNode(std::make_shared<LangMenu>(this, "Language select"));
   addNode(std::make_shared<TimeMenu>(this, "Timezone select"));
+  addNode(std::make_shared<logViewerMenu>(this, "Log viewer"));
   addNode(std::make_shared<MenuExec>("Wipe cache partitions", [](Menu *){
     wipe_cache();
   }));;

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SRCS += $(CURDIR)/main.cpp $(INCDIR)/outputLine.cpp \
 	$(INCDIR)/settingsMenu.cpp $(INCDIR)/audioMenu.cpp $(INCDIR)/videoMenu.cpp \
 	$(INCDIR)/infoLog.cpp \
 	$(INCDIR)/config.cpp \
+	$(INCDIR)/logViewer.cpp \
+	$(INCDIR)/logViewerMenu.cpp \
 	$(INCDIR)/subAppRouter.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(INCDIR)/xbeScanner.cpp \

--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,7 @@ int main(void) {
   // FIXME: Font path should be read from theme
   Font f(r, HOME "vegur.ttf");
 
-  SubAppRouter router;
+  SubAppRouter &router = *SubAppRouter::getInstance();
 
   auto menu = std::make_shared<Menu>(config, r);
   router.push(menu);


### PR DESCRIPTION
Very basic fullscreen log viewer subapp.

Planned enhancements:
- Scrollbar to display position with the log
- Prevent scrolling up past one full screen of the log
- Support for scrolling by page
- Automatic scrolling while the dpad is held down (dependent on #90 )
- Indication that the log is explicitly locked to the bottom and will scroll as new events come in (in case we start using more log messages in the FTP server or some other interesting background thread)