### PR TITLE
gitignore: Ignores iso files and CLion editor artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin/
 *.lib
 *.pdb
 *.iso
+
+.gdbinit
+.idea/


### PR DESCRIPTION
- Ignores the .iso build artifact
- Ignores any local `.gdbinit` files (these are needed for CLion + xemu as a remote GDB host)
- Ignores `.idea/` so any JetBrains editor cruft doesn't get accidentally submitted.