### PR TITLE
codestyle: Adds clang-format config.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,189 @@
+# Use clang-format 10.0 or later.
+# See https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+#
+# Note: Some options are commented out as they are only available after 10.0
+#       and clang-format is not forwards-compatible (it fails on unknown keys).
+#
+---
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+#AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: DontAlign
+#AlignOperands: Align
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+#AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+#AttributeMacros:
+#- __capability
+BasedOnStyle: Google
+BinPackArguments: true
+BinPackParameters: false
+#BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: true
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: false
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: false
+#  BeforeLambdaBody: false
+#  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyNamespace: true
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+#BreakBeforeConceptDeclarations: false
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: false
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 92
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+#EmptyLineBeforeAccessModifier: Always
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IncludeBlocks: Merge
+IncludeCategories:
+- Priority: 2
+  Regex: ^<ext/.*\.h>
+  SortPriority: 0
+- Priority: 1
+  Regex: ^<.*\.h>
+  SortPriority: 0
+- Priority: 2
+  Regex: ^<.*
+  SortPriority: 0
+- Priority: 3
+  Regex: .*
+  SortPriority: 0
+IncludeIsMainRegex: ([-_](test|unittest))?$
+IncludeIsMainSourceRegex: ''
+#IndentAccessModifiers: false
+#IndentCaseBlocks: true
+IndentCaseLabels: false
+#IndentExternBlock: NoIndent
+IndentGotoLabels: false
+IndentPPDirectives: None
+#IndentRequires: false
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+#InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+#LambdaBodyIndentation: Signature
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+PenaltyBreakAssignment: 25
+PenaltyBreakBeforeFirstCallParameter: 5
+PenaltyBreakComment: 100
+PenaltyBreakFirstLessLess: 200
+PenaltyBreakString: 250
+PenaltyBreakTemplateDeclaration: 0
+PenaltyExcessCharacter: 50
+#PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+RawStringFormats:
+- BasedOnStyle: google
+  CanonicalDelimiter: ''
+  Delimiters:
+  - cc
+  - CC
+  - cpp
+  - Cpp
+  - CPP
+  - c++
+  - C++
+  Language: Cpp
+- BasedOnStyle: google
+  CanonicalDelimiter: ''
+  Delimiters:
+  - pb
+  - PB
+  - proto
+  - PROTO
+  EnclosingFunctions:
+  - EqualsProto
+  - EquivToProto
+  - PARSE_PARTIAL_TEXT_PROTO
+  - PARSE_TEST_PROTO
+  - PARSE_TEXT_PROTO
+  - ParseTextOrDie
+  - ParseTextProtoOrDie
+  - ParseTestProto
+  - ParsePartialTestProto
+  Language: TextProto
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+#SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: C++11
+#StatementAttributeLikeMacros:
+#- Q_EMIT
+#StatementMacros:
+#- Q_UNUSED
+#- QT_REQUIRE_VERSION
+TabWidth: 2
+UseCRLF: false
+UseTab: Never
+...


### PR DESCRIPTION
Adds a `.clang-format` that approximates the prevailing style used in this repo.

This should partially resolve #92 