### PR TITLE
input: Adds analog axis handling.

### DIFF
--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -113,6 +113,11 @@ public:
   void onBackPressed() override { back(); }
   void onBPressed() override { back(); }
 
+  void onLeftStickDigitalUpPressed() override { onUpPressed(); }
+  void onLeftStickDigitalDownPressed() override { onDownPressed(); }
+  void onLeftStickDigitalLeftPressed() override { onLeftPressed(); }
+  void onLeftStickDigitalRightPressed() override { onRightPressed(); }
+
   void pageUp();
   void pageDown();
   void back();

--- a/Includes/subApp.h
+++ b/Includes/subApp.h
@@ -58,6 +58,33 @@ public:
   virtual void onBlackPressed() {}
   virtual void onBlackReleased() {}
 
+  // Virtual events emitted when the left analog stick is deflected past the deadzone.
+  virtual void onLeftStickDigitalUpPressed() {}
+  virtual void onLeftStickDigitalUpReleased() {}
+  virtual void onLeftStickDigitalDownPressed() {}
+  virtual void onLeftStickDigitalDownReleased() {}
+  virtual void onLeftStickDigitalLeftPressed() {}
+  virtual void onLeftStickDigitalLeftReleased() {}
+  virtual void onLeftStickDigitalRightPressed() {}
+  virtual void onLeftStickDigitalRightReleased() {}
+
+  // Virtual events emitted when the right analog stick is deflected past the deadzone.
+  virtual void onRightStickDigitalUpPressed() {}
+  virtual void onRightStickDigitalUpReleased() {}
+  virtual void onRightStickDigitalDownPressed() {}
+  virtual void onRightStickDigitalDownReleased() {}
+  virtual void onRightStickDigitalLeftPressed() {}
+  virtual void onRightStickDigitalLeftReleased() {}
+  virtual void onRightStickDigitalRightPressed() {}
+  virtual void onRightStickDigitalRightReleased() {}
+
+  virtual void onLeftStickXChanged(int newValue) { (void)newValue; }
+  virtual void onLeftStickYChanged(int newValue) { (void)newValue; }
+  virtual void onRightStickXChanged(int newValue) { (void)newValue; }
+  virtual void onRightStickYChanged(int newValue) { (void)newValue; }
+  virtual void onLeftTriggerChanged(int newValue) { (void)newValue; }
+  virtual void onRightTriggerChanged(int newValue) { (void)newValue; }
+
   int getAutoRepeatInterval(SDL_GameControllerButton button) const {
     auto it = autoRepeatIntervals.find(button);
     if (it == autoRepeatIntervals.end()) {

--- a/Includes/subAppRouter.h
+++ b/Includes/subAppRouter.h
@@ -33,9 +33,21 @@ private:
   LONGLONG ticksPerMillisecond;
   LONGLONG lastFrameStartTicks;
 
+  // Percentage of full deflection that an analog stick must be moved before being
+  // considered an intentional input.
+  float analogStickDeadzone{ 0.38f };
+
+  // Percentage of full deflection that a trigger must be moved before being considered an
+  // intentional input.
+  float triggerDeadzone{ 0.05f };
+
   // Maps {(PlayerID, Button), timestamp} to track when virtual button press events should
   // be fired while a button is held down.
   std::map<std::pair<int, SDL_GameControllerButton>, LONGLONG> buttonRepeatTimers;
+
+  // Maps {(PlayerID, Button), value} to track the value of analog axes in order to emit
+  // virtual digital button events.
+  std::map<std::pair<int, SDL_GameControllerAxis>, int> lastAxisState;
 };
 
 #endif // NEVOLUTIONX_INCLUDES_SUBAPPROUTER_H_


### PR DESCRIPTION
Changes in preparation for using the right analog stick for a superscroll implementation for #94. This also maps the left analog stick to the dpad inputs so the user can use either to navigate the menu. A nice followup would be to enable the automatic repeat behavior as well, the repeat mechanism would need to be extended to support the virtual  "stick as digital" events.

Note: I don't actually have a controller handy for the next few days so this is a prospective change using a keyboard input in xemu.