### PR TITLE
codestyle: Fixes pre-commit behavior on deleted C++ files.

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -88,8 +88,9 @@ fi
 exec 1>&2
 
 
-changed_filenames="$(git diff --cached --name-only)"
-changed_c_filenames="$(echo "${changed_filenames}" | grep -E '.*\.(c|cpp|h|hpp)$')"
+added_and_modified_filenames="$(git diff --cached --name-only --diff-filter=d)"
+changed_c_filenames="$(echo "${added_and_modified_filenames}" | \
+                            grep -E '.*\.(c|cpp|h|hpp)$')"
 
 
 # Allow blank line at EOF.


### PR DESCRIPTION
Fixes my silly mistake where deleting a file will cause the pre-commit hook to fail (as it blindly tries to run `clang-format` on a file that no longer exists).