### PR TITLE
menu: Makes XBE scanner cooperative instead of async.

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -158,9 +158,8 @@ MenuXbe::MenuXbe(MenuNode* parent, std::string const& label, std::string const& 
     updateScanningLabel();
     XBEScanner::scanPath(
         remainingScanPaths.front(),
-        [this](bool succeeded, std::vector<XBEScanner::XBEInfo> const& items) {
-          this->onScanCompleted(succeeded, items);
-        });
+        [this](bool succeeded, std::list<XBEScanner::XBEInfo> const& items,
+               long long duration) { this->onScanCompleted(succeeded, items, duration); });
   }
 }
 
@@ -223,7 +222,8 @@ void MenuXbe::updateScanningLabel() {
 }
 
 void MenuXbe::onScanCompleted(bool succeeded,
-                              std::vector<XBEScanner::XBEInfo> const& items) {
+                              std::list<XBEScanner::XBEInfo> const& items,
+                              long long duration) {
   std::string path = remainingScanPaths.front();
   remainingScanPaths.pop_front();
 
@@ -233,14 +233,13 @@ void MenuXbe::onScanCompleted(bool succeeded,
     discoveredItems.insert(discoveredItems.end(), std::make_move_iterator(begin(items)),
                            std::make_move_iterator(end(items)));
   }
+  InfoLog::outputLine("Completed scanning '%s' for XBEs in %lld ms", path.c_str(), duration);
 
   if (!remainingScanPaths.empty()) {
     updateScanningLabel();
-    XBEScanner::scanPath(
-        remainingScanPaths.front(),
-        [this](bool succeeded, std::vector<XBEScanner::XBEInfo> const& items) {
-          this->onScanCompleted(succeeded, items);
-        });
+    XBEScanner::scanPath(remainingScanPaths.front(),
+                         [this](bool s, std::list<XBEScanner::XBEInfo> const& i,
+                                long long d) { this->onScanCompleted(s, i, d); });
     return;
   }
 

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -76,7 +76,9 @@ public:
 private:
   void superscroll(bool moveToPrevious);
   void updateScanningLabel();
-  void onScanCompleted(bool succeeded, std::vector<XBEScanner::XBEInfo> const& items);
+  void onScanCompleted(bool succeeded,
+                       std::list<XBEScanner::XBEInfo> const& items,
+                       long long duration);
   void createChildren();
 
   std::mutex childNodesLock;

--- a/Includes/timing.cpp
+++ b/Includes/timing.cpp
@@ -1,0 +1,6 @@
+#include "timing.h"
+
+long long millisSince(const std::chrono::steady_clock::time_point& ref) {
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now - ref).count();
+}

--- a/Includes/timing.h
+++ b/Includes/timing.h
@@ -1,0 +1,8 @@
+#ifndef NEVOLUTIONX_TIMING_H
+#define NEVOLUTIONX_TIMING_H
+
+#include <chrono>
+
+long long millisSince(const std::chrono::steady_clock::time_point& ref);
+
+#endif // NEVOLUTIONX_TIMING_H

--- a/Includes/xbeScanner.cpp
+++ b/Includes/xbeScanner.cpp
@@ -5,8 +5,10 @@
 #include <winnt.h>
 #endif
 
+#include "infoLog.h"
+#include "timing.h"
+
 #define XBE_TYPE_MAGIC (0x48454258)
-#define XBE_NAME_SIZE 40
 #define SECTORSIZE 0x1000
 
 static bool scan(std::string const& path, std::vector<XBEScanner::XBEInfo>& ret);
@@ -20,120 +22,114 @@ XBEScanner* XBEScanner::getInstance() {
   return XBEScanner::singleton;
 }
 
-XBEScanner::XBEScanner() : running(true) {
-  scannerThread = std::thread(threadMain, this);
-}
-
-XBEScanner::~XBEScanner() {
-  running = false;
-  queue.emplace("", nullptr);
-  if (scannerThread.joinable()) {
-    scannerThread.join();
-  }
-}
-
 void XBEScanner::scanPath(const std::string& path, Callback&& callback) {
   XBEScanner::getInstance()->addJob(path, callback);
 }
 
 void XBEScanner::addJob(std::string const& path, const Callback& callback) {
-  std::lock_guard<std::mutex> lock(queueMutex);
   queue.emplace(path, callback);
-  jobPending.notify_one();
 }
 
-void XBEScanner::threadMain(XBEScanner* scanner) {
-  while (scanner->running) {
-    QueueItem task;
-    {
-      std::unique_lock<std::mutex> lock(scanner->queueMutex);
-      scanner->jobPending.wait(lock, [=] { return !scanner->queue.empty(); });
-      if (!scanner->running) {
-        break;
-      }
-      task = scanner->queue.front();
-      scanner->queue.pop();
-    }
+void XBEScanner::process(int timeout) {
+  if (queue.empty()) {
+    return;
+  }
 
-    std::string const& path = task.first;
-    std::vector<XBEInfo> xbes;
-    bool succeeded = scan(path, xbes);
-
-    task.second(succeeded, xbes);
+  auto& task = queue.front();
+  if (task.scan(timeout)) {
+    queue.pop();
   }
 }
 
-static bool scan(std::string const& path, std::vector<XBEScanner::XBEInfo>& ret) {
-#ifndef NXDK
-  return FALSE;
-#else
-  std::string workPath = path;
-  if (workPath.back() != '\\') {
-    workPath += '\\';
+XBEScanner::QueueItem::QueueItem(std::string p, XBEScanner::Callback c) :
+    path(std::move(p)), callback(std::move(c)) {
+  xbeData.resize(SECTORSIZE);
+}
+
+XBEScanner::QueueItem::~QueueItem() {
+  if (dirHandle != INVALID_HANDLE_VALUE) {
+    CloseHandle(dirHandle);
   }
+}
 
-  std::string searchmask = workPath + "*";
-  std::string xbePath;
-  char xbeName[XBE_NAME_SIZE + 1];
-  char* xbeData = static_cast<char*>(malloc(SECTORSIZE));
-  FILE* tmpFILE = nullptr;
-  WIN32_FIND_DATAA fData;
-  HANDLE fHandle = FindFirstFileA(searchmask.c_str(), &fData);
-  if (fHandle == INVALID_HANDLE_VALUE) {
-    return FALSE;
-  }
+bool XBEScanner::QueueItem::scan(int timeoutMillis) {
+  auto start = std::chrono::steady_clock::now();
 
-  do {
-    if (fData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-      xbePath = workPath + fData.cFileName + "\\default.xbe";
-      tmpFILE = fopen(xbePath.c_str(), "rb");
-      if (tmpFILE != nullptr) {
-        size_t read_bytes = fread(xbeData, 1, SECTORSIZE, tmpFILE);
-        PXBE_FILE_HEADER xbe = (PXBE_FILE_HEADER)xbeData;
-        if (xbe->SizeOfHeaders > read_bytes) {
-          xbeData = static_cast<char*>(realloc(xbeData, xbe->SizeOfHeaders));
-          xbe = (PXBE_FILE_HEADER)xbeData;
-          read_bytes += fread(&xbeData[read_bytes], 1, xbe->SizeOfHeaders - read_bytes,
-                              tmpFILE);
-        }
-        if (xbe->Magic != XBE_TYPE_MAGIC || xbe->ImageBase != XBE_DEFAULT_BASE
-            || xbe->ImageBase > (uint32_t)xbe->CertificateHeader
-            || (uint32_t)xbe->CertificateHeader + 4 >= (xbe->ImageBase + xbe->SizeOfHeaders)
-            || xbe->SizeOfHeaders > read_bytes) {
-          continue;
-        }
-        PXBE_CERTIFICATE_HEADER xbeCert =
-            (PXBE_CERTIFICATE_HEADER)&xbeData[(uint32_t)xbe->CertificateHeader
-                                              - xbe->ImageBase];
-        memset(xbeName, 0x00, sizeof(xbeName));
-        int offset = 0;
-        while (offset < XBE_NAME_SIZE) {
-          if (xbeCert->TitleName[offset] < 0x0100) {
-            sprintf(&xbeName[offset], "%c", (char)xbeCert->TitleName[offset]);
-          } else {
-            sprintf(&xbeName[offset], "%c", '?');
-          }
-          if (xbeCert->TitleName[offset] == 0x0000) {
-            break;
-          }
-          ++offset;
-        }
-
-        // Some homebrew content may not have a name in the certification
-        // header, so fallback to using the path as the name.
-        if (!strlen(xbeName)) {
-          strncpy(xbeName, fData.cFileName, sizeof(xbeName) - 1);
-        }
-        fclose(tmpFILE);
-        tmpFILE = nullptr;
-
-        ret.emplace_back(xbeName, xbePath);
-      }
+  if (dirHandle == INVALID_HANDLE_VALUE) {
+    InfoLog::outputLine("Starting scan of %s", path.c_str());
+    results.clear();
+    scanStart = std::chrono::steady_clock::now();
+    if (!openDir()) {
+      callback(false, results, millisSince(scanStart));
+      return true;
     }
-  } while (FindNextFile(fHandle, &fData) != 0);
-  free(xbeData);
-  FindClose(fHandle);
-#endif // #ifndef NXDK
+  }
 
-  return TRUE;
+  for (auto elapsedTime = millisSince(start); elapsedTime < timeoutMillis;
+       elapsedTime = millisSince(start)) {
+    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      continue;
+    }
+
+    processFile(path + findData.cFileName + "\\default.xbe");
+
+    if (!FindNextFile(dirHandle, &findData)) {
+      CloseHandle(dirHandle);
+      dirHandle = INVALID_HANDLE_VALUE;
+      callback(true, results, millisSince(scanStart));
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool XBEScanner::QueueItem::openDir() {
+  std::string searchmask = path + "*";
+  dirHandle = FindFirstFileA(searchmask.c_str(), &findData);
+  return (dirHandle != INVALID_HANDLE_VALUE);
+}
+
+void XBEScanner::QueueItem::processFile(const std::string& xbePath) {
+  FILE* xbeFile = fopen(xbePath.c_str(), "rb");
+  if (!xbeFile) {
+    return;
+  }
+
+  size_t read_bytes = fread(xbeData.data(), 1, SECTORSIZE, xbeFile);
+  auto xbe = (PXBE_FILE_HEADER)xbeData.data();
+  if (xbe->SizeOfHeaders > read_bytes) {
+    if (xbeData.size() < xbe->SizeOfHeaders) {
+      xbeData.resize(xbe->SizeOfHeaders);
+    }
+    read_bytes += fread(&xbeData[read_bytes], 1, xbe->SizeOfHeaders - read_bytes, xbeFile);
+  }
+  if (xbe->Magic != XBE_TYPE_MAGIC || xbe->ImageBase != XBE_DEFAULT_BASE
+      || xbe->ImageBase > (uint32_t)xbe->CertificateHeader
+      || (uint32_t)xbe->CertificateHeader + 4 >= (xbe->ImageBase + xbe->SizeOfHeaders)
+      || xbe->SizeOfHeaders > read_bytes) {
+    return;
+  }
+  auto xbeCert =
+      (PXBE_CERTIFICATE_HEADER)&xbeData[(uint32_t)xbe->CertificateHeader - xbe->ImageBase];
+
+  for (int offset = 0; offset < XBE_NAME_SIZE; ++offset) {
+    if (xbeCert->TitleName[offset] < 0x0100) {
+      xbeName[offset] = (char)xbeCert->TitleName[offset];
+    } else if (xbeCert->TitleName[offset]) {
+      xbeName[offset] = '?';
+    } else {
+      xbeName[offset] = 0;
+      break;
+    }
+  }
+
+  // Some homebrew content may not have a name in the certification
+  // header, so fallback to using the path as the name.
+  if (!strlen(xbeName)) {
+    strncpy(xbeName, findData.cFileName, sizeof(xbeName) - 1);
+  }
+  fclose(xbeFile);
+
+  results.emplace_back(xbeName, xbePath);
 }

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SRCS += \
 	$(INCDIR)/subAppRouter.cpp \
 	$(INCDIR)/subsystems.cpp \
 	$(INCDIR)/timeMenu.cpp \
+	$(INCDIR)/timing.cpp \
 	$(INCDIR)/videoMenu.cpp \
 	$(INCDIR)/wipeCache.cpp \
 	$(INCDIR)/xbeScanner.cpp \


### PR DESCRIPTION
Testing on real hardware, I found that when calling `FindFirstFile` on a secondary thread stalls for 20+ seconds (on my v1.0 box). Specifically the underlying call to `NtOpenFile` blocks for a substantial amount of time. This seems to be consistent for any (existing) directory, regardless of the content, and changing to an explicit `CreateThread` based approach instead of using `std::thread` did not resolve the problem, nor did changing the sync-related flags on the `NtOpenFile` call.

Until I can figure out why this is happening, I've converted `XBEScanner` to operate in a cooperative manner. The main loop polls the scanner and gives an approximate time limit for the scan. Theoretically this timeout is based on framerate, but it seemed like I was only getting ~20fps on hardware, so I've made it scan at least one file per frame and set the target to 15 fps.

I also added some additional debugging output so it's clear how much time it takes to scan. I suspect users with large libraries will be pretty unhappy with the current performance, so hopefully there's some easy improvements to be had.