### PR TITLE
menu: Makes XBE scanner synchronous.

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -158,9 +158,8 @@ MenuXbe::MenuXbe(MenuNode* parent, std::string const& label, std::string const& 
     updateScanningLabel();
     XBEScanner::scanPath(
         remainingScanPaths.front(),
-        [this](bool succeeded, std::vector<XBEScanner::XBEInfo> const& items) {
-          this->onScanCompleted(succeeded, items);
-        });
+        [this](bool succeeded, std::list<XBEScanner::XBEInfo> const& items,
+               long long duration) { this->onScanCompleted(succeeded, items, duration); });
   }
 }
 
@@ -223,7 +222,9 @@ void MenuXbe::updateScanningLabel() {
 }
 
 void MenuXbe::onScanCompleted(bool succeeded,
-                              std::vector<XBEScanner::XBEInfo> const& items) {
+                              std::list<XBEScanner::XBEInfo> const& items,
+                              long long duration) {
+  (void)duration;
   std::string path = remainingScanPaths.front();
   remainingScanPaths.pop_front();
 
@@ -238,9 +239,8 @@ void MenuXbe::onScanCompleted(bool succeeded,
     updateScanningLabel();
     XBEScanner::scanPath(
         remainingScanPaths.front(),
-        [this](bool succeeded, std::vector<XBEScanner::XBEInfo> const& items) {
-          this->onScanCompleted(succeeded, items);
-        });
+        [this](bool succeeded, std::list<XBEScanner::XBEInfo> const& items,
+               long long duration) { this->onScanCompleted(succeeded, items, duration); });
     return;
   }
 

--- a/Includes/menu.hpp
+++ b/Includes/menu.hpp
@@ -76,7 +76,9 @@ public:
 private:
   void superscroll(bool moveToPrevious);
   void updateScanningLabel();
-  void onScanCompleted(bool succeeded, std::vector<XBEScanner::XBEInfo> const& items);
+  void onScanCompleted(bool succeeded,
+                       std::list<XBEScanner::XBEInfo> const& items,
+                       long long duration);
   void createChildren();
 
   std::mutex childNodesLock;

--- a/Includes/xbeScanner.cpp
+++ b/Includes/xbeScanner.cpp
@@ -1,12 +1,10 @@
 #include "xbeScanner.h"
-
-#ifdef NXDK
 #include <windows.h>
 #include <winnt.h>
-#endif
+#include "infoLog.h"
+#include "timing.h"
 
 #define XBE_TYPE_MAGIC (0x48454258)
-#define XBE_NAME_SIZE 40
 #define SECTORSIZE 0x1000
 
 static bool scan(std::string const& path, std::vector<XBEScanner::XBEInfo>& ret);
@@ -20,6 +18,7 @@ XBEScanner* XBEScanner::getInstance() {
   return XBEScanner::singleton;
 }
 
+#if SCANNER_THREADED
 XBEScanner::XBEScanner() : running(true) {
   scannerThread = std::thread(threadMain, this);
 }
@@ -31,11 +30,18 @@ XBEScanner::~XBEScanner() {
     scannerThread.join();
   }
 }
+#endif
 
 void XBEScanner::scanPath(const std::string& path, Callback&& callback) {
+#if SCANNER_THREADED
   XBEScanner::getInstance()->addJob(path, callback);
+#else
+  auto job = QueueItem(path, callback);
+  job.scan();
+#endif
 }
 
+#if SCANNER_THREADED
 void XBEScanner::addJob(std::string const& path, const Callback& callback) {
   std::lock_guard<std::mutex> lock(queueMutex);
   queue.emplace(path, callback);
@@ -62,78 +68,89 @@ void XBEScanner::threadMain(XBEScanner* scanner) {
     task.second(succeeded, xbes);
   }
 }
+#endif
 
-static bool scan(std::string const& path, std::vector<XBEScanner::XBEInfo>& ret) {
-#ifndef NXDK
-  return FALSE;
-#else
-  std::string workPath = path;
-  if (workPath.back() != '\\') {
-    workPath += '\\';
+XBEScanner::QueueItem::QueueItem(std::string p, XBEScanner::Callback c) :
+    path(std::move(p)), callback(std::move(c)) {
+  xbeData.resize(SECTORSIZE);
+}
+
+XBEScanner::QueueItem::~QueueItem() {
+  if (dirHandle != INVALID_HANDLE_VALUE) {
+    CloseHandle(dirHandle);
   }
+}
 
-  std::string searchmask = workPath + "*";
-  std::string xbePath;
-  char xbeName[XBE_NAME_SIZE + 1];
-  char* xbeData = static_cast<char*>(malloc(SECTORSIZE));
-  FILE* tmpFILE = nullptr;
-  WIN32_FIND_DATAA fData;
-  HANDLE fHandle = FindFirstFileA(searchmask.c_str(), &fData);
-  if (fHandle == INVALID_HANDLE_VALUE) {
-    return FALSE;
+void XBEScanner::QueueItem::scan() {
+  if (dirHandle == INVALID_HANDLE_VALUE) {
+    InfoLog::outputLine("Starting scan of %s", path.c_str());
+    results.clear();
+    scanStart = std::chrono::steady_clock::now();
+    if (!openDir()) {
+      callback(false, results, millisSince(scanStart));
+      return;
+    }
   }
 
   do {
-    if (fData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-      xbePath = workPath + fData.cFileName + "\\default.xbe";
-      tmpFILE = fopen(xbePath.c_str(), "rb");
-      if (tmpFILE != nullptr) {
-        size_t read_bytes = fread(xbeData, 1, SECTORSIZE, tmpFILE);
-        PXBE_FILE_HEADER xbe = (PXBE_FILE_HEADER)xbeData;
-        if (xbe->SizeOfHeaders > read_bytes) {
-          xbeData = static_cast<char*>(realloc(xbeData, xbe->SizeOfHeaders));
-          xbe = (PXBE_FILE_HEADER)xbeData;
-          read_bytes += fread(&xbeData[read_bytes], 1, xbe->SizeOfHeaders - read_bytes,
-                              tmpFILE);
-        }
-        if (xbe->Magic != XBE_TYPE_MAGIC || xbe->ImageBase != XBE_DEFAULT_BASE
-            || xbe->ImageBase > (uint32_t)xbe->CertificateHeader
-            || (uint32_t)xbe->CertificateHeader + 4 >= (xbe->ImageBase + xbe->SizeOfHeaders)
-            || xbe->SizeOfHeaders > read_bytes) {
-          continue;
-        }
-        PXBE_CERTIFICATE_HEADER xbeCert =
-            (PXBE_CERTIFICATE_HEADER)&xbeData[(uint32_t)xbe->CertificateHeader
-                                              - xbe->ImageBase];
-        memset(xbeName, 0x00, sizeof(xbeName));
-        int offset = 0;
-        while (offset < XBE_NAME_SIZE) {
-          if (xbeCert->TitleName[offset] < 0x0100) {
-            sprintf(&xbeName[offset], "%c", (char)xbeCert->TitleName[offset]);
-          } else {
-            sprintf(&xbeName[offset], "%c", '?');
-          }
-          if (xbeCert->TitleName[offset] == 0x0000) {
-            break;
-          }
-          ++offset;
-        }
-
-        // Some homebrew content may not have a name in the certification
-        // header, so fallback to using the path as the name.
-        if (!strlen(xbeName)) {
-          strncpy(xbeName, fData.cFileName, sizeof(xbeName) - 1);
-        }
-        fclose(tmpFILE);
-        tmpFILE = nullptr;
-
-        ret.emplace_back(xbeName, xbePath);
-      }
+    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      continue;
     }
-  } while (FindNextFile(fHandle, &fData) != 0);
-  free(xbeData);
-  FindClose(fHandle);
-#endif // #ifndef NXDK
 
-  return TRUE;
+    processFile(path + findData.cFileName + "\\default.xbe");
+  } while (FindNextFile(dirHandle, &findData));
+
+  CloseHandle(dirHandle);
+  dirHandle = INVALID_HANDLE_VALUE;
+  callback(true, results, millisSince(scanStart));
+}
+
+bool XBEScanner::QueueItem::openDir() {
+  std::string searchmask = path + "*";
+  dirHandle = FindFirstFile(searchmask.c_str(), &findData);
+  return (dirHandle != INVALID_HANDLE_VALUE);
+}
+
+void XBEScanner::QueueItem::processFile(const std::string& xbePath) {
+  FILE* xbeFile = fopen(xbePath.c_str(), "rb");
+  if (!xbeFile) {
+    return;
+  }
+
+  size_t read_bytes = fread(xbeData.data(), 1, SECTORSIZE, xbeFile);
+  auto xbe = (PXBE_FILE_HEADER)xbeData.data();
+  if (xbe->SizeOfHeaders > read_bytes) {
+    if (xbeData.size() < xbe->SizeOfHeaders) {
+      xbeData.resize(xbe->SizeOfHeaders);
+    }
+    read_bytes += fread(&xbeData[read_bytes], 1, xbe->SizeOfHeaders - read_bytes, xbeFile);
+  }
+  if (xbe->Magic != XBE_TYPE_MAGIC || xbe->ImageBase != XBE_DEFAULT_BASE
+      || xbe->ImageBase > (uint32_t)xbe->CertificateHeader
+      || (uint32_t)xbe->CertificateHeader + 4 >= (xbe->ImageBase + xbe->SizeOfHeaders)
+      || xbe->SizeOfHeaders > read_bytes) {
+    return;
+  }
+  auto xbeCert =
+      (PXBE_CERTIFICATE_HEADER)&xbeData[(uint32_t)xbe->CertificateHeader - xbe->ImageBase];
+
+  for (int offset = 0; offset < XBE_NAME_SIZE; ++offset) {
+    if (xbeCert->TitleName[offset] < 0x0100) {
+      xbeName[offset] = (char)xbeCert->TitleName[offset];
+    } else if (xbeCert->TitleName[offset]) {
+      xbeName[offset] = '?';
+    } else {
+      xbeName[offset] = 0;
+      break;
+    }
+  }
+
+  // Some homebrew content may not have a name in the certification
+  // header, so fallback to using the path as the name.
+  if (!strlen(xbeName)) {
+    strncpy(xbeName, findData.cFileName, sizeof(xbeName) - 1);
+  }
+  fclose(xbeFile);
+
+  results.emplace_back(xbeName, xbePath);
 }


### PR DESCRIPTION
Making XBE scanning synchronous until #110 is implemented as the async thread gets starved, leading to multi-minute scan times on a library w/ 160 XBEs.

The downside is that it now takes ~10 extra seconds to get off the initial black screen (presumably this has a direct relationship w/ number of XBEs). The black screen will at least print that a scan is being done so it's not a total user experience disaster :)