### PR TITLE
menu: Blanks framebuffer before exiting/launching XBEs.

### DIFF
--- a/Includes/menu.cpp
+++ b/Includes/menu.cpp
@@ -2,10 +2,8 @@
 #include "3rdparty/NaturalSort/natural_sort.hpp"
 #include "infoLog.h"
 #include "settingsMenu.hpp"
+#include "xbeLauncher.h"
 #include "xbeScanner.h"
-#ifdef NXDK
-#include <hal/xbox.h>
-#endif
 
 // Character used in the config.json to separate multiple path entries.
 #define PATH_DELIMITER ','
@@ -297,7 +295,7 @@ MenuLaunch::~MenuLaunch() {
 void MenuLaunch::execute(Menu*) {
   InfoLog::outputLine("Launching xbe %s\n", this->path.c_str());
 #ifdef NXDK
-  XLaunchXBE(const_cast<char*>(this->path.c_str()));
+  XBELauncher::launch(path);
 #endif
 }
 
@@ -334,7 +332,7 @@ Menu::Menu(const Config& config, Renderer& renderer) :
       this->rootNode.addNode(newNode);
     } else if (!static_cast<std::string>(e["type"]).compare("reboot")) {
       std::shared_ptr<MenuExec> newNode = std::make_shared<MenuExec>(
-          e["label"], [](Menu*) { exit(0); });
+          e["label"], [](Menu*) { XBELauncher::exitToDashboard(); });
       this->rootNode.addNode(newNode);
     } else if (!static_cast<std::string>(e["type"]).compare("settings")) {
       std::shared_ptr<MenuNode> newNode = std::make_shared<settingsMenu>(currentMenu,

--- a/Includes/xbeLauncher.cpp
+++ b/Includes/xbeLauncher.cpp
@@ -1,0 +1,24 @@
+#include "xbeLauncher.h"
+#include <hal/video.h>
+#include <hal/xbox.h>
+
+void XBELauncher::exitToDashboard() {
+  showLaunchImage();
+  // TODO: Switch to XLaunchXBE(nullptr) if XboxDev/nxdk#501 is merged.
+  exit(0);
+}
+
+void XBELauncher::launch(std::string const& xbePath) {
+  showLaunchImage();
+  XLaunchXBE(const_cast<char*>(xbePath.c_str()));
+}
+
+void XBELauncher::showLaunchImage() {
+  VIDEO_MODE mode = XVideoGetMode();
+
+  // TODO(XboxDev/nxdk#507): Display launch image instead when framebuffer can be persisted.
+  unsigned char* fb = XVideoGetFB();
+  memset(fb, 0, mode.width * mode.height * (mode.bpp >> 3));
+  XVideoFlushFB();
+  XVideoSetVideoEnable(FALSE);
+}

--- a/Includes/xbeLauncher.h
+++ b/Includes/xbeLauncher.h
@@ -1,0 +1,17 @@
+#ifndef NEVOLUTIONX_XBELAUNCHER_H
+#define NEVOLUTIONX_XBELAUNCHER_H
+
+#include <string>
+
+// Launches an XBE (or the dashboard).
+class XBELauncher {
+public:
+  static void exitToDashboard();
+  static void launch(std::string const& xbePath);
+
+private:
+  // TODO(#113): Add support for a pre-launch image.
+  static void showLaunchImage();
+};
+
+#endif // NEVOLUTIONX_XBELAUNCHER_H

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRCS += \
 	$(INCDIR)/timing.cpp \
 	$(INCDIR)/videoMenu.cpp \
 	$(INCDIR)/wipeCache.cpp \
+	$(INCDIR)/xbeLauncher.cpp \
 	$(INCDIR)/xbeScanner.cpp \
 	$(CURDIR)/3rdparty/SDL_FontCache/SDL_FontCache.c
 


### PR DESCRIPTION
- Blanks the framebuffer before exiting the dashboard (see discussion in XboxDev/nxdk/#511)
- Adds a bottleneck for activities that exit the dashboard to allow a future loading screen (in prep for #113 )