### PR TITLE
Update GitHub CI build and add binary folder to artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: NevolutionX
-          path: '*.iso'
+          path: |
+            *.iso
+            bin
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flex bison clang lld llvm clang-format
-          echo "${PWD}/nxdk/bin" >> $GITHUB_PATH
       - name: Check for new format errors
         run: |
           find . | grep -E '.*\.(c|cpp|h|hpp)$' | grep -Ev '(3rdparty|nxdk)/' | xargs clang-format --dry-run -Werror
       - name: Build
-        env:
-          NXDK_DIR: nxdk
         run: |
+          eval $(./nxdk/bin/activate -s)
           make -j$(nproc)
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
I made a slight modification to use NXDK's `bin/activate` script to setup its own build system.

Plus added ability to upload bin folder to artifact without need to extract iso every time.