### PR TITLE
fix(xbescanner): scan paths missing trailing slashes

### DIFF
--- a/Sources/xbeScanner.cpp
+++ b/Sources/xbeScanner.cpp
@@ -92,6 +92,10 @@ XBEScanner::QueueItem::~QueueItem() {
 void XBEScanner::QueueItem::scan() {
 #ifdef NXDK
   if (dirHandle == INVALID_HANDLE_VALUE) {
+    auto pathEnd = &path.back();
+    if (strcmp(pathEnd, "\\") != 0) {
+      path.append("\\");
+    }
     InfoLog::outputLine(InfoLog::INFO, "Starting scan of %s", path.c_str());
     results.clear();
     scanStart = std::chrono::steady_clock::now();


### PR DESCRIPTION
An issue loading directories/files is experienced when a trailing backslash is not included in the config menu scan path, the dashboard menu result is '<empty>'. The default, sampleconfig.json, includes menu scan paths without a trailing backslash and so it was expected.

related: #74